### PR TITLE
Remove opentelemery strict dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "playwright==1.51",
     "tldextract",
     "loguru",
-    "opentelemetry-proto==1.28.0",
     "pydantic",
     "pydantic-settings",
     "fastapi[standard]",


### PR DESCRIPTION
Not sure why that dependency was needed, the default is 1.33.1