### PR TITLE
Support more models via small agent changes

### DIFF
--- a/frontend/src/components/settings.tsx
+++ b/frontend/src/components/settings.tsx
@@ -3,6 +3,7 @@ import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
 import { appContext } from "../hooks/provider";
 import SignInModal from "./signin";
 import { useSettingsStore } from "./store";
+import MonacoEditor from "@monaco-editor/react";
 import { settingsAPI } from "./views/api";
 import {
   Input,
@@ -44,14 +45,14 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ isOpen, onClose }) => {
 
   const MODEL_OPTIONS = [
     { value: "azure-ai-foundry", label: "Azure AI Foundry Template" },
-    { value: "gpt-4o-2024-08-06", label: "GPT-4o" },
-    { value: "gpt-4o-mini-2024-07-18", label: "GPT-4o Mini" },
     { value: "gpt-4.1-2025-04-14", label: "GPT-4.1" },
     { value: "gpt-4.1-mini-2025-04-14", label: "GPT-4.1 Mini" },
+    { value: "openrouter", label: "OpenRouter" },
     { value: "gpt-4.1-nano-2025-04-14", label: "GPT-4.1 Nano" },
     { value: "o4-mini-2025-04-16", label: "O4 Mini" },
     { value: "o3-mini-2025-01-31", label: "O3 Mini" },
-    { value: "o1-2024-12-17", label: "O1" },
+    { value: "gpt-4o-2024-08-06", label: "GPT-4o" },
+    { value: "gpt-4o-mini-2024-07-18", label: "GPT-4o Mini" },
   ];
 
   const AZURE_AI_FOUNDRY_YAML = `model_config: &client
@@ -68,6 +69,28 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ isOpen, onClose }) => {
         scopes:
           - https://cognitiveservices.azure.com/.default
     max_retries: 10
+
+orchestrator_client: *client
+coder_client: *client
+web_surfer_client: *client
+file_surfer_client: *client
+action_guard_client: *client
+`;
+
+  const OPENROUTER_YAML = `model_config: &client
+  provider: OpenAIChatCompletionClient
+  config:
+    model: "MODEL_NAME"
+    base_url: "https://openrouter.ai/api/v1"
+    api_key: "KEY"
+    model_info: # change per model
+       vision: true 
+       function_calling: true # required true for file_surfer, but will still work if file_surfer is not needed
+       json_output: false
+       family: unknown
+       structured_output: false
+  max_retries: 5
+
 
 orchestrator_client: *client
 coder_client: *client
@@ -203,6 +226,11 @@ action_guard_client: *client
       if (modelName === "azure-ai-foundry") {
         handleUpdateConfig({ model_configs: AZURE_AI_FOUNDRY_YAML });
         message.success("Azure AI Foundry configuration applied");
+        return;
+      }
+      if (modelName === "openrouter") {
+        handleUpdateConfig({ model_configs: OPENROUTER_YAML });
+        message.success("OpenRouter configuration applied");
         return;
       }
       const yamlLines = config.model_configs?.split("\n") || [];
@@ -542,21 +570,21 @@ action_guard_client: *client
                         <div className="text-sm mb-1">
                           Advanced Configuration (YAML)
                         </div>
-                        <TextArea
+                        <MonacoEditor
                           value={config.model_configs}
-                          onChange={(
-                            e: React.ChangeEvent<HTMLTextAreaElement>
-                          ) => {
-                            if (validateYamlConfig(e.target.value)) {
-                              handleUpdateConfig({
-                                model_configs: e.target.value,
-                              });
-                            }
+                          onChange={(value) => {
+                            handleUpdateConfig({
+                              model_configs: value,
+                            });
                           }}
-                          placeholder="Enter YAML configuration..."
-                          style={{
-                            minHeight: "300px",
+                          language="yaml"
+                          height="300px"
+                          options={{
                             fontFamily: "monospace",
+                            minimap: { enabled: false },
+                            wordWrap: "on",
+                            scrollBeyondLastLine: false,
+                            theme: darkMode === "dark" ? "vs-dark" : "light",
                           }}
                         />
                       </div>

--- a/src/magentic_ui/agents/_coder.py
+++ b/src/magentic_ui/agents/_coder.py
@@ -145,11 +145,13 @@ async def _coding_and_debug(
         )
 
         # Re-initialize model context to meet token limit quota
-        await model_context.clear()
-        for msg in context:
-            await model_context.add_message(msg)
-        token_limited_context = await model_context.get_messages()
-
+        try:
+            await model_context.clear()
+            for msg in context:
+                await model_context.add_message(msg)
+            token_limited_context = await model_context.get_messages()
+        except Exception:
+            token_limited_context = context
         # Generate code using the model.
         create_result = await model_client.create(
             messages=token_limited_context, cancellation_token=cancellation_token
@@ -263,10 +265,13 @@ async def _summarize_coding(
     )
 
     # Re-initialize model context to meet token limit quota
-    await model_context.clear()
-    for msg in input_messages:
-        await model_context.add_message(msg)
-    token_limited_input_messages = await model_context.get_messages()
+    try:
+        await model_context.clear()
+        for msg in input_messages:
+            await model_context.add_message(msg)
+        token_limited_input_messages = await model_context.get_messages()
+    except Exception:
+        token_limited_input_messages = input_messages
 
     summary_result = await model_client.create(
         messages=token_limited_input_messages, cancellation_token=cancellation_token

--- a/src/magentic_ui/agents/file_surfer/_file_surfer.py
+++ b/src/magentic_ui/agents/file_surfer/_file_surfer.py
@@ -277,12 +277,21 @@ class FileSurfer(BaseChatAgent, Component[FileSurferConfig]):
             )
 
             # Re-initialize model context to meet token limit quota
-            await self._model_context.clear()
-            for msg in (
-                history + self.DEFAULT_SYSTEM_MESSAGES + [context_message, task_message]
-            ):
-                await self._model_context.add_message(msg)
-            token_limited_history = await self._model_context.get_messages()
+            try:
+                await self._model_context.clear()
+                for msg in (
+                    history
+                    + self.DEFAULT_SYSTEM_MESSAGES
+                    + [context_message, task_message]
+                ):
+                    await self._model_context.add_message(msg)
+                token_limited_history = await self._model_context.get_messages()
+            except Exception:
+                token_limited_history = list(
+                    history
+                    + self.DEFAULT_SYSTEM_MESSAGES
+                    + [context_message, task_message]
+                )
 
             create_result = await self._model_client.create(
                 messages=token_limited_history,

--- a/src/magentic_ui/teams/orchestrator/_utils.py
+++ b/src/magentic_ui/teams/orchestrator/_utils.py
@@ -1,3 +1,8 @@
+import json
+import re
+from typing import Any, Optional
+
+
 def is_accepted_str(user_input: str) -> bool:
     LIST_OF_ACCEPTED_STRS = [
         "accept",
@@ -20,3 +25,18 @@ def is_accepted_str(user_input: str) -> bool:
     if user_input in LIST_OF_ACCEPTED_STRS:
         return True
     return False
+
+
+def extract_json_from_string(s: str) -> Optional[Any]:
+    """
+    Searches for a JSON object within the string and returns the loaded JSON if found, otherwise returns None.
+    """
+    # Regex to find JSON objects (greedy, matches first { to last })
+    match = re.search(r"\{.*\}", s, re.DOTALL)
+    if match:
+        json_str = match.group(0)
+        try:
+            return json.loads(json_str)
+        except json.JSONDecodeError:
+            return None
+    return None


### PR DESCRIPTION
Support more models via small agent changes

- orchestrator json smarter retry with exception message
- orchestrator find json in output if output itself is not json
- websurfer remove extra args
- bypass token context if exceptions are thrown (doesnt work for a lot of clients), created issue #67  and temporary patch in this code
- websurfer auto enable json mode if tool calling is not supported by client

UI change to settings: use a proper code editor for the yaml field