### PR TITLE
Removed duplicate --user-proxy-type definition

### DIFF
--- a/src/magentic_ui/_cli.py
+++ b/src/magentic_ui/_cli.py
@@ -338,14 +338,6 @@ def main() -> None:
         help="ActionGuard policy ('always', 'never', 'auto-conservative', 'auto-permissive'; default: never)",
     )
 
-    parser.add_argument(
-        "--user-proxy-type",
-        dest="user_proxy_type",
-        type=str,
-        default=None,
-        help="UserProxy type ('dummy'; default: None)",
-    )
-
     args = parser.parse_args()
 
     # Validate user proxy type


### PR DESCRIPTION
Fixed argparse conflict by removing duplicate --user-proxy-type definition. This issue prevented the `_cli.py` from running as seen in the error below.

Command executed:
`python -m magentic_ui._cli`

Error:
```
RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/matheus/repos/05-27-2025/magentic-ui/.venv/lib/python3.12/site-packages/magentic_ui/_cli.py", line 446, in <module>
    main()
  File "/home/matheus/repos/05-27-2025/magentic-ui/.venv/lib/python3.12/site-packages/magentic_ui/_cli.py", line 341, in main
    parser.add_argument(
  File "/usr/lib/python3.12/argparse.py", line 1507, in add_argument
    return self._add_action(action)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/argparse.py", line 1889, in _add_action
    self._optionals._add_action(action)
  File "/usr/lib/python3.12/argparse.py", line 1709, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/argparse.py", line 1521, in _add_action
    self._check_conflict(action)
  File "/usr/lib/python3.12/argparse.py", line 1658, in _check_conflict
    conflict_handler(action, confl_optionals)
  File "/usr/lib/python3.12/argparse.py", line 1667, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument --user-proxy-type: conflicting option string: --user-proxy-type
```

Fix:
Removed duplicate `--user-proxy-type` definition. I was then able to run the system in my command line interface with no issues.

To-Do: 
- Document how to run the CLI locally using `python -m magentic_ui._cli`