### PR TITLE
Add .gitattributes to enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/src/magentic_ui/_docker.py
+++ b/src/magentic_ui/_docker.py
@@ -15,9 +15,7 @@ PYTHON_BUILD_CONTEXT = "magentic-ui-python-env"
 
 def get_docker_client() -> docker.DockerClient:
     if platform.system() == "Windows":
-        client = docker.from_env()
-        client.api.base_url = "npipe:////./pipe/dockerDesktopLinuxEngine"
-        return client
+        os.environ["DOCKER_HOST"] = "npipe:////./pipe/dockerDesktopLinuxEngine"
     return docker.from_env()
 
 

--- a/src/magentic_ui/_docker.py
+++ b/src/magentic_ui/_docker.py
@@ -15,7 +15,9 @@ PYTHON_BUILD_CONTEXT = "magentic-ui-python-env"
 
 def get_docker_client() -> docker.DockerClient:
     if platform.system() == "Windows":
-        return docker.DockerClient(base_url='npipe:////./pipe/dockerDesktopLinuxEngine')
+        client = docker.from_env()
+        client.api.base_url = "npipe:////./pipe/dockerDesktopLinuxEngine"
+        return client
     return docker.from_env()
 
 

--- a/src/magentic_ui/_docker.py
+++ b/src/magentic_ui/_docker.py
@@ -1,5 +1,6 @@
 import docker
 import os
+import platform
 import sys
 from docker.errors import DockerException, ImageNotFound
 import logging
@@ -12,9 +13,15 @@ VNC_BROWSER_BUILD_CONTEXT = "magentic-ui-browser-docker"
 PYTHON_BUILD_CONTEXT = "magentic-ui-python-env"
 
 
+def get_docker_client() -> docker.DockerClient:
+    if platform.system() == "Windows":
+        return docker.DockerClient(base_url='npipe:////./pipe/dockerDesktopLinuxEngine')
+    return docker.from_env()
+
+
 def check_docker_running() -> bool:
     try:
-        client = docker.from_env()
+        client = get_docker_client()
         client.ping()  # type: ignore
         return True
     except (DockerException, ConnectionError):
@@ -49,8 +56,8 @@ def check_docker_image(image_name: str, client: docker.DockerClient) -> bool:
 
 def build_browser_image(client: docker.DockerClient | None = None) -> None:
     if client is None:
-        client = docker.from_env()
-    client = docker.from_env()
+        client = get_docker_client()
+    client = get_docker_client()
     build_image(
         VNC_BROWSER_IMAGE + ":latest",
         os.path.join(_PACKAGE_DIR, "docker", VNC_BROWSER_BUILD_CONTEXT),
@@ -60,8 +67,8 @@ def build_browser_image(client: docker.DockerClient | None = None) -> None:
 
 def build_python_image(client: docker.DockerClient | None = None) -> None:
     if client is None:
-        client = docker.from_env()
-    client = docker.from_env()
+        client = get_docker_client()
+    client = get_docker_client()
     build_image(
         PYTHON_IMAGE + ":latest",
         os.path.join(_PACKAGE_DIR, "docker", PYTHON_BUILD_CONTEXT),
@@ -85,8 +92,8 @@ def check_browser_image(client: docker.DockerClient | None = None) -> bool:
     if not check_docker_access():
         return False
     if client is None:
-        client = docker.from_env()
-    client = docker.from_env()
+        client = get_docker_client()
+    client = get_docker_client()
     return check_docker_image(VNC_BROWSER_IMAGE, client)
 
 
@@ -94,6 +101,6 @@ def check_python_image(client: docker.DockerClient | None = None) -> bool:
     if not check_docker_access():
         return False
     if client is None:
-        client = docker.from_env()
-    client = docker.from_env()
+        client = get_docker_client()
+    client = get_docker_client()
     return check_docker_image(PYTHON_IMAGE, client)

--- a/src/magentic_ui/backend/cli.py
+++ b/src/magentic_ui/backend/cli.py
@@ -47,7 +47,7 @@ def ui(
     config: Optional[str] = None,
     rebuild_docker: Optional[bool] = False,
     ssl_certfile: Optional[str] = None,
-    ssl_keyfile: Optional[str] = None
+    ssl_keyfile: Optional[str] = None,
 ):
     """
     Run Magentic-UI.
@@ -149,7 +149,7 @@ def ui(
             else None,
             env_file=env_file_path,
             ssl_certfile=ssl_certfile,
-            ssl_keyfile=ssl_keyfile
+            ssl_keyfile=ssl_keyfile,
         )
     else:
         uvicorn.run(
@@ -161,7 +161,7 @@ def ui(
             reload_excludes=["**/alembic/*", "**/alembic.ini", "**/versions/*"]
             if reload
             else None,
-            env_file=env_file_path
+            env_file=env_file_path,
         )
 
 

--- a/src/magentic_ui/backend/cli.py
+++ b/src/magentic_ui/backend/cli.py
@@ -46,6 +46,8 @@ def ui(
     upgrade_database: bool = False,
     config: Optional[str] = None,
     rebuild_docker: Optional[bool] = False,
+    ssl_certfile: Optional[str] = None,
+    ssl_keyfile: Optional[str] = None
 ):
     """
     Run Magentic-UI.
@@ -60,6 +62,8 @@ def ui(
         database-uri (str, optional): Database URI to connect to. Defaults to None.
         config (str, optional): Path to the config file. Defaults to `config.yaml`.
         rebuild_docker: bool, optional: Rebuild the docker images. Defaults to False.
+        ssl_certfile (str, optional): Path to SSL certificate file. Defaults to None.
+        ssl_keyfile (str, optional): Path to SSL key file. Defaults to None.
     """
 
     typer.echo(typer.style("Starting Magentic-UI", fg=typer.colors.GREEN, bold=True))
@@ -133,17 +137,32 @@ def ui(
         for key, value in env_vars.items():
             temp_env.write(f"{key}={value}\n")
 
-    uvicorn.run(
-        "magentic_ui.backend.web.app:app",
-        host=host,
-        port=port,
-        workers=workers,
-        reload=reload,
-        reload_excludes=["**/alembic/*", "**/alembic.ini", "**/versions/*"]
-        if reload
-        else None,
-        env_file=env_file_path,
-    )
+    if ssl_certfile and ssl_keyfile:
+        uvicorn.run(
+            "magentic_ui.backend.web.app:app",
+            host=host,
+            port=port,
+            workers=workers,
+            reload=reload,
+            reload_excludes=["**/alembic/*", "**/alembic.ini", "**/versions/*"]
+            if reload
+            else None,
+            env_file=env_file_path,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile
+        )
+    else:
+        uvicorn.run(
+            "magentic_ui.backend.web.app:app",
+            host=host,
+            port=port,
+            workers=workers,
+            reload=reload,
+            reload_excludes=["**/alembic/*", "**/alembic.ini", "**/versions/*"]
+            if reload
+            else None,
+            env_file=env_file_path
+        )
 
 
 @app.command()


### PR DESCRIPTION
This pull request introduces improvements to Docker client handling for better platform compatibility, adds SSL support to the `ui` command, and ensures consistent line endings for shell scripts. Below are the most significant changes:

### Docker client handling improvements:
* Added a new `get_docker_client` function in `src/magentic_ui/_docker.py` to handle platform-specific Docker client initialization, particularly for Windows environments.
* Replaced direct calls to `docker.from_env()` with `get_docker_client()` across multiple functions, including `check_docker_running`, `build_browser_image`, `build_python_image`, `check_browser_image`, and `check_python_image`. This ensures consistent Docker client initialization. [[1]](diffhunk://#diff-b21de835acbb814bcd3525214ad13b6f5398b51209b2aa89f562dcd22f8dec3fR15-R23) [[2]](diffhunk://#diff-b21de835acbb814bcd3525214ad13b6f5398b51209b2aa89f562dcd22f8dec3fL51-R59) [[3]](diffhunk://#diff-b21de835acbb814bcd3525214ad13b6f5398b51209b2aa89f562dcd22f8dec3fL62-R70) [[4]](diffhunk://#diff-b21de835acbb814bcd3525214ad13b6f5398b51209b2aa89f562dcd22f8dec3fL73-R88)

### SSL support for `ui` command:
* Added `ssl_certfile` and `ssl_keyfile` parameters to the `ui` command in `src/magentic_ui/backend/cli.py`, enabling optional SSL configuration. [[1]](diffhunk://#diff-a593ee4bbc87c1890b51e92a17a2bc2bc1b7b6ba020b1713ec0db174d50627e0R49-R50) [[2]](diffhunk://#diff-a593ee4bbc87c1890b51e92a17a2bc2bc1b7b6ba020b1713ec0db174d50627e0R65-R66)
* Updated the `uvicorn.run` call to conditionally include SSL certificate and key file paths if provided, ensuring secure HTTPS support. [[1]](diffhunk://#diff-a593ee4bbc87c1890b51e92a17a2bc2bc1b7b6ba020b1713ec0db174d50627e0R140) [[2]](diffhunk://#diff-a593ee4bbc87c1890b51e92a17a2bc2bc1b7b6ba020b1713ec0db174d50627e0R151-R164)

### Miscellaneous:
* Updated `.gitattributes` to enforce LF line endings for all `.sh` files, ensuring consistent behavior across platforms.This pull request includes a small change to the `.gitattributes` file. The change ensures that all `.sh` files will have line endings normalized to LF (`eol=lf`).
