### PR TITLE
fix: resolve browser connection timeout on macOS by using IPv4 addres…

### DIFF
--- a/src/magentic_ui/tools/playwright/browser/headless_docker_playwright_browser.py
+++ b/src/magentic_ui/tools/playwright/browser/headless_docker_playwright_browser.py
@@ -35,7 +35,7 @@ class HeadlessDockerPlaywrightBrowser(
 
     Properties:
         browser_address (str): Returns the WebSocket address for connecting to the browser.
-            Format: "ws://localhost:{playwright_port}"
+            Format: "ws://127.0.0.1:{playwright_port}" (or container name if inside_docker=True)
 
     Example:
         ```python
@@ -61,7 +61,7 @@ class HeadlessDockerPlaywrightBrowser(
         self._hostname = (
             f"magentic-ui-headless-browser_{self._playwright_port}"
             if inside_docker
-            else "localhost"
+            else "127.0.0.1"
         )
 
     @property

--- a/src/magentic_ui/tools/playwright/browser/vnc_docker_playwright_browser.py
+++ b/src/magentic_ui/tools/playwright/browser/vnc_docker_playwright_browser.py
@@ -97,7 +97,7 @@ class VncDockerPlaywrightBrowser(
         self._hostname = (
             f"magentic-ui-vnc-browser_{self._playwright_websocket_path}_{self._novnc_port}"
             if inside_docker
-            else "localhost"
+            else "127.0.0.1"
         )
         self._docker_name = f"magentic-ui-vnc-browser_{self._playwright_websocket_path}_{self._novnc_port}"
 
@@ -117,7 +117,7 @@ class VncDockerPlaywrightBrowser(
         self._hostname = (
             f"magentic-ui-vnc-browser_{self._playwright_websocket_path}_{self._novnc_port}"
             if self._inside_docker
-            else "localhost"
+            else "127.0.0.1"
         )
         self._docker_name = f"magentic-ui-vnc-browser_{self._playwright_websocket_path}_{self._novnc_port}"
         playwright_sock.close()


### PR DESCRIPTION
## Problem
Fixes browser connection timeout issues on macOS where Playwright Docker browsers fail to connect with:
## Root Cause
IPv4/IPv6 address resolution conflict:
- Docker containers listen on IPv4 addresses only
- `localhost` may resolve to IPv6 (`::1`) on some macOS configurations
- Results in connection refused errors

## Solution
- Replace `localhost` with `127.0.0.1` in browser hostname configuration
- Forces IPv4 connections while maintaining Docker internal communication compatibility
- Affects `VncDockerPlaywrightBrowser` and `HeadlessDockerPlaywrightBrowser`

## Testing
- ✅ Verified address generation uses `127.0.0.1` when `inside_docker=False`
- ✅ Confirmed Docker internal communication still uses container names when `inside_docker=True`
- ✅ Maintains full backward compatibility

## Files Changed
- `src/magentic_ui/tools/playwright/browser/vnc_docker_playwright_browser.py`
- `src/magentic_ui/tools/playwright/browser/headless_docker_playwright_browser.py`