### PR TITLE
Fix sidebar overflow and Add session ID checks

### DIFF
--- a/frontend/src/components/views/manager.tsx
+++ b/frontend/src/components/views/manager.tsx
@@ -364,7 +364,7 @@ export const SessionManager: React.FC = () => {
 
   const chatViews = useMemo(() => {
     return sessions.map((s: Session) => {
-      const status = sessionRunStatuses[s.id] as RunStatus;
+      const status = (s.id ? sessionRunStatuses[s.id] : undefined) as RunStatus;
       const isSessionPotentiallyActive = [
         "active",
         "awaiting_input",

--- a/frontend/src/components/views/sidebar.tsx
+++ b/frontend/src/components/views/sidebar.tsx
@@ -103,17 +103,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const renderSessionGroup = (sessions: Session[]) => (
     <>
       {sessions.map((s) => {
-        const status = sessionRunStatuses[s.id];
-        const isActive = [
+        const status = s.id ? sessionRunStatuses[s.id] : undefined;
+        const isActive = status ? [
           "active",
           "awaiting_input",
           "pausing",
           "paused",
-        ].includes(status);
+        ].includes(status) : false;
         return (
           <div key={s.id} className="relative">
             <div
-              className={`group flex items-center justify-between p-2 py-1 text-sm ${
+              className={`group flex items-center p-2 py-1 text-sm ${
                 isLoading
                   ? "pointer-events-none opacity-50"
                   : "cursor-pointer hover:bg-tertiary"
@@ -124,10 +124,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
               }`}
               onClick={() => !isLoading && onSelectSession(s)}
             >
-              <div className="flex items-center gap-2 flex-1">
-                <span className="truncate text-sm">
-                  {s.name.slice(0, 20)}
-                  {s.name.length > 20 ? "..." : ""}
+              <div className="flex items-center gap-2 flex-1 min-w-0">
+                <span className="truncate text-sm max-w-[140px]">
+                  {s.name}
                 </span>
                 {s.id && (
                   <SessionRunStatusIndicator
@@ -135,7 +134,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   />
                 )}
               </div>
-              <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity w-8 justify-end flex-shrink-0">
                 <Dropdown
                   trigger={["click"]}
                   overlay={


### PR DESCRIPTION
Mainly addressing Issue #183 with some additional safety checks:
- Fixed sidebar session names being too long due to different language characters (see this [image](https://private-user-images.githubusercontent.com/16881909/454295576-753d1ba4-63fd-4db1-8841-42361d468e4a.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDk3NTEzMTcsIm5iZiI6MTc0OTc1MTAxNywicGF0aCI6Ii8xNjg4MTkwOS80NTQyOTU1NzYtNzUzZDFiYTQtNjNmZC00ZGIxLTg4NDEtNDIzNjFkNDY4ZTRhLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA2MTIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNjEyVDE3NTY1N1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTBmNTBiZWQzMzY2OTUxM2JhNmU0NzQ2ZDk1NTVlYWM4NzljZDg5NzkxMjg4MTQ4NzlhMTg2MjI3YjQwOTc2MGEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.usMVjm9uJ3mYxUBxNspVwlUQkvjEd_1GQnJOkJNiHBU)), preventing three-dot menu from being pushed out of view
- Added small safety logic for checking session identifiers to prevent TypeScript errors when session IDs are undefined

Fixed version:
![image](https://github.com/user-attachments/assets/32314555-0e2f-4010-bb6a-496583b5307a)