### PR TITLE
Add agent icons to steps in frontend (#110)

### DIFF
--- a/frontend/src/components/common/Icon.tsx
+++ b/frontend/src/components/common/Icon.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Code,Folder,Globe,User } from "lucide-react";
+
+
+export const CoderIcon = ({ className = '', size = 16 }: { className?: string, size?: number }) => (
+  <Code className={className} size={size} />
+);
+
+export const FileSurferIcon = ({ className = '', size = 16 }: { className?: string, size?: number }) => (
+  <Folder className={className} size={size} />
+);
+
+export const WebSurferIcon = ({ className = '', size = 16 }: { className?: string, size?: number }) => (
+  <Globe className={className} size={size} />
+);
+
+export const UserIcon = ({ className = '', size = 16 }: { className?: string, size?: number }) => (
+  <User className={className} size={size} />
+);

--- a/frontend/src/components/views/chat/plan.tsx
+++ b/frontend/src/components/views/chat/plan.tsx
@@ -18,6 +18,11 @@ import { Trash2 } from "lucide-react";
 import { appContext } from "../../../hooks/provider";
 import { IPlanStep } from "../../types/plan";
 import AutoResizeTextarea from "../../common/AutoResizeTextarea";
+import { CoderIcon,FileSurferIcon,WebSurferIcon,UserIcon } from "../../common/Icon";
+
+
+
+
 
 // Debounce hook
 const useDebounce = (callback: Function, delay: number) => {
@@ -146,8 +151,20 @@ const PlanView: React.FC<PlanProps> = ({
     handlePlanChange(items);
   };
 
+
+const getAgentIcon = (agentName: string | undefined): JSX.Element => {
+  const lowerCaseName = (agentName || '').toLowerCase();
+  
+  if (lowerCaseName.includes('coder')) return <CoderIcon />;
+  if (lowerCaseName.includes('file') && lowerCaseName.includes('surfer')) return <FileSurferIcon />;
+  if (lowerCaseName.includes('web') && lowerCaseName.includes('surfer')) return <WebSurferIcon />;
+  if (lowerCaseName.includes('user')) return <UserIcon />;
+  return <UserIcon />;
+};
+
   const noop = () => {};
 
+  console.log("PlanView rendered with plan:", localPlan);
   return (
     <>
       {!viewOnly && onRegeneratePlan && (
@@ -220,6 +237,11 @@ const PlanView: React.FC<PlanProps> = ({
                               >
                                 Step {index + 1}
                               </span>
+                              <div className="flex items-center ml-2 relative group">
+                                  <div className="text-gray-600 dark:text-gray-300">
+                                    {getAgentIcon(item.agent_name)}
+                                  </div>
+                                </div>
                             </div>
                             <div className="border-transparent p-1  px-2 mt-2.5 flex-1 rounded">
                               <div className="flex items-center">


### PR DESCRIPTION
## Description

This PR adds visual identification of agent types in the workflow steps by displaying agent-specific icons (coder, file surfer, web surfer, user).

### Changes Made

- Created a new `Icon.tsx` component in `src/components/common/` that exports specialized icons for different agent types
- Modified `plan.tsx` to display the appropriate icon next to step numbers based on the agent type
- Icons provide visual distinction between different agent types in the workflow

### Implementation Details

- Used `lucide-react` library for clean, consistent SVG icons
- Added icons for:
  - Coder (`<Code />`)
  - File Surfer (`<Folder />`)
  - Web Surfer (`<Globe />`)
  - User (`<User />`)
- Positioned icons next to step numbers for easy visibility

### Screenshots

<img width="986" alt="PR_ISSUE_110" src="https://github.com/user-attachments/assets/8c6e4dd6-6a03-4633-9d10-a820f67a219f" />


Fixes #110