### PR TITLE
Bugfix: StdioServerForm Command Input Stripping Spaces

### DIFF
--- a/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/mcpServerForms/MCPServerForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/mcpServerForms/MCPServerForm.tsx
@@ -6,13 +6,13 @@ import { MCPServerConfig, NamedMCPServerConfig } from "./types";
 
 export const DEFAULT_STDIO_PARAMS: MCPServerConfig = {
     type: "StdioServerParams",
-    command: "docker",
-    args: ["run", "-i", "--rm", "mcp/memory"],
+    command: "",
+    args: [],
     read_timeout_seconds: 5,
 };
 export const DEFAULT_SSE_PARAMS: MCPServerConfig = {
     type: "SseServerParams",
-    url: "http://localhost:3001/sse",
+    url: "",
     headers: {},
     timeout: 5,
     sse_read_timeout: 300,

--- a/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/mcpServerForms/SseServerForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/mcpServerForms/SseServerForm.tsx
@@ -14,6 +14,7 @@ const SseServerForm: React.FC<{
             <Tooltip title={sseUrlError ? 'URL is required' : ''} open={sseUrlError ? undefined : false}>
                 <Form.Item label="URL" required>
                     <Input
+                        placeholder="http://localhost:8000/sse"
                         value={value.url}
                         status={sseUrlError ? 'error' : ''}
                         onChange={e =>

--- a/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/mcpServerForms/StdioServerForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/mcpServerForms/StdioServerForm.tsx
@@ -8,17 +8,23 @@ const StdioServerForm: React.FC<{
     onValueChanged: (idx: number, updated: StdioServerParams) => void;
 }> = ({ value, idx, onValueChanged }) => {
     const stdioCommandError = !value.command || value.command.trim() === '';
-
+    
     let command = value.command ?? "";
-    if (value.args) {
+    if (value.args !== undefined && value.args.length > 0) {
         command = command.concat(" ").concat(value.args.join(" "));
     }
-
+    
     const handleCommandValueChanged: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-        const parts = event.target.value?.split(" ").map(part => part.trim()).filter(part => part.length > 0);
+        const parts = event.target.value?.trimStart().split(" ");
+        
+        if (parts.length > 1) {
+            // Trim the command only if there is an arg. Otherwise you can't type a space.
+            parts[0] = parts[0].trim()
+        }
 
         const command = parts.length > 0 ? parts[0] : "";
         const args = parts.length > 1 ? parts.slice(1) : [];
+
 
         onValueChanged(idx, {
             ...value,

--- a/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/mcpServerForms/StdioServerForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/mcpServerForms/StdioServerForm.tsx
@@ -39,6 +39,7 @@ const StdioServerForm: React.FC<{
             <Tooltip title={stdioCommandError ? 'Command is required' : 'Provide the command and arguments, e.g. "npx -y mcp-server-fetch"'}>
                 <Form.Item label="Command (including args)" required>
                     <Input
+                        placeholder="npx -y mcp-server-fetch"
                         value={command}
                         status={stdioCommandError ? 'error' : ''}
                         onChange={handleCommandValueChanged}

--- a/frontend/src/components/store.tsx
+++ b/frontend/src/components/store.tsx
@@ -21,6 +21,7 @@ export interface GeneralConfig {
   model_client_configs: {orchestrator: any, web_surfer: any, coder: any, file_surfer: any, action_guard: any};
   mcp_agent_configs: any[];
   retrieve_relevant_plans: "never" | "hint" | "reuse"; // this is for using task centric memory to retrieve relevant plans
+  server_url: string; // Optional server URL for VNC/live view
 }
 
 const defaultConfig: GeneralConfig = {
@@ -34,6 +35,7 @@ const defaultConfig: GeneralConfig = {
   do_bing_search: false,
   websurfer_loop: false,
   retrieve_relevant_plans: "never",
+  server_url: "localhost",
   mcp_agent_configs: [],
   model_client_configs: {
     "orchestrator": DEFAULT_OPENAI,
@@ -41,7 +43,7 @@ const defaultConfig: GeneralConfig = {
     "coder": DEFAULT_OPENAI,
     "file_surfer": DEFAULT_OPENAI,
     "action_guard": PROVIDER_FORM_MAP[DEFAULT_OPENAI.provider].presets["gpt-4.1-nano-2025-04-14"],
-  }
+  },
 };
 
 interface SettingsState {

--- a/frontend/src/components/views/chat/detail_viewer.tsx
+++ b/frontend/src/components/views/chat/detail_viewer.tsx
@@ -11,6 +11,7 @@ import BrowserIframe from "./DetailViewer/browser_iframe";
 import BrowserModal from "./DetailViewer/browser_modal";
 import FullscreenOverlay from "./DetailViewer/fullscreen_overlay"; // Import our new component
 import { IPlan } from "../../types/plan";
+import { useSettingsStore } from "../../store";
 // Define VNC component props type
 interface VncScreenProps {
   url: string;
@@ -75,6 +76,8 @@ const DetailViewer: React.FC<DetailViewerProps> = ({
 
   // State for tracking if control was handed back from modal
   const [showControlHandoverForm, setShowControlHandoverForm] = useState(false);
+
+  const config = useSettingsStore((state) => state.config);
 
   // Handle take control action
   const handleTakeControl = () => {
@@ -184,6 +187,9 @@ const DetailViewer: React.FC<DetailViewerProps> = ({
       );
     }
 
+    // Use server_url from config if set, otherwise default to localhost
+    const serverHost = config.server_url || "localhost";
+
     return (
       <div className="flex-1 w-full h-full flex flex-col">
         {viewMode === "iframe" ? (
@@ -212,7 +218,7 @@ const DetailViewer: React.FC<DetailViewerProps> = ({
           >
             <Suspense fallback={<div>Loading VNC viewer...</div>}>
               <VncScreen
-                url={`ws://localhost:${novncPort}`}
+                url={`ws://${serverHost}:${novncPort}`}
                 scaleViewport
                 background="#000000"
                 style={{
@@ -230,7 +236,7 @@ const DetailViewer: React.FC<DetailViewerProps> = ({
         )}
       </div>
     );
-  }, [novncPort, viewMode, runStatus, onPause, isControlMode]);
+  }, [novncPort, viewMode, runStatus, onPause, isControlMode, config.server_url]);
 
   return (
     <>


### PR DESCRIPTION
The StdioServerForm's command input was stripping spaces too eagerly, so you couldn't actually type a space. Updated the logic to only strip the space after the "command" only after some args have been provided.

Also moved default values for StdioServerForm's command and SseServerForm's url to be placeholders instead.