### PR TITLE
Fix model_info bug blocking Ollama model configs

### DIFF
--- a/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OllamaModelConfigForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OllamaModelConfigForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
-import { Input, Form, Button, Switch, Flex, Collapse } from "antd";
-import { ModelConfigFormProps, OllamaModelConfig } from "./types";
+import { Input, Form, Button, Switch, Flex, Collapse, Select } from "antd";
+import { ModelConfigFormProps, ModelFamilySchema, OllamaModelConfig } from "./types";
 
 export const DEFAULT_OLLAMA: OllamaModelConfig = {
   provider: "autogen_ext.models.ollama.OllamaChatCompletionClient",
@@ -14,18 +14,20 @@ export const DEFAULT_OLLAMA: OllamaModelConfig = {
 const ADVANCED_DEFAULTS = {
   vision: true,
   function_calling: true,
-  json_output: false,
+  json_output: true,
+  family: "unknown" as const,
   structured_output: false,
+  multiple_system_messages: false,
 };
 
 function normalizeConfig(config: any, hideAdvancedToggles?: boolean) {
-  const newConfig = { ...config };
+  const newConfig = { ...DEFAULT_OLLAMA, ...config };
   if (hideAdvancedToggles) {
-    if (newConfig.model_info) delete newConfig.model_info;
+    if (newConfig.config.model_info) delete newConfig.config.model_info;
   } else {
-    newConfig.model_info = {
+    newConfig.config.model_info = {
       ...ADVANCED_DEFAULTS,
-      ...(newConfig.model_info || {})
+      ...(newConfig.config.model_info || {})
     };
   }
   return newConfig;
@@ -33,6 +35,7 @@ function normalizeConfig(config: any, hideAdvancedToggles?: boolean) {
 
 export const OllamaModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange, onSubmit, value, hideAdvancedToggles }) => {
   const [form] = Form.useForm();
+
   const handleValuesChange = (_: any, allValues: any) => {
     const mergedConfig = { ...DEFAULT_OLLAMA.config, ...allValues.config };
     const normalizedConfig = normalizeConfig(mergedConfig, hideAdvancedToggles);
@@ -45,15 +48,17 @@ export const OllamaModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
     const newValue = { ...DEFAULT_OLLAMA, config: normalizedConfig };
     if (onSubmit) onSubmit(newValue);
   };
+
   useEffect(() => {
     if (value) {
-      form.setFieldsValue(value);
+      form.setFieldsValue(normalizeConfig(value, hideAdvancedToggles))
     }
   }, [value, form]);
+
   return (
     <Form
       form={form}
-      initialValues={value || DEFAULT_OLLAMA.config}
+      initialValues={normalizeConfig(value, hideAdvancedToggles)}
       onFinish={handleSubmit}
       onValuesChange={handleValuesChange}
       layout="vertical"
@@ -66,29 +71,41 @@ export const OllamaModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
           <Form.Item label="Host" name={["config", "host"]}>
             <Input />
           </Form.Item>
-          <Collapse>
-          <Collapse.Panel key="1" header="Optional Properties">
-            <Form.Item label="Max Retries" name={["config", "max_retries"]} rules={[{ type: "number", min: 1, max: 20, message: "Enter a value between 1 and 20" }]}>
-              <Input type="number" />
-            </Form.Item>
-            {!hideAdvancedToggles && (
-              <Flex gap="small" wrap justify="space-between">
-                <Form.Item label="Vision" name={["config", "model_info", "vision"]} valuePropName="checked">
-                  <Switch />
-                </Form.Item>
-                <Form.Item label="Function Calling" name={["config", "model_info", "function_calling"]} valuePropName="checked">
-                  <Switch />
-                </Form.Item>
-                <Form.Item label="JSON Output" name={["config", "model_info", "json_output"]} valuePropName="checked">
-                  <Switch />
-                </Form.Item>
-                <Form.Item label="Structured Output" name={["config", "model_info", "structured_output"]} valuePropName="checked">
-                  <Switch />
-                </Form.Item>
-              </Flex>
-            )}
-          </Collapse.Panel>
-        </Collapse>
+          <Collapse style={{ width: "100%" }}>
+            <Collapse.Panel key="1" header="Optional Properties">
+              <Form.Item label="Max Retries" name={["config", "max_retries"]} rules={[{ type: "number", min: 1, max: 20, message: "Enter a value between 1 and 20" }]}>
+                <Input type="number" />
+              </Form.Item>
+              {!hideAdvancedToggles && (
+                <Flex gap="small" wrap justify="space-between">
+                  <Form.Item label="Model Family" name={["config", "model_info", "family"]}>
+                    <Select placeholder="Select model family" popupMatchSelectWidth={false}>
+                      {ModelFamilySchema.options.map((family) => (
+                        <Select.Option key={family} value={family}>
+                          {family}
+                        </Select.Option>
+                      ))}
+                    </Select>
+                  </Form.Item>
+                  <Form.Item label="Vision" name={["config", "model_info", "vision"]} valuePropName="checked">
+                    <Switch checked={value?.config.model_info?.vision ?? false} />
+                  </Form.Item>
+                  <Form.Item label="Function Calling" name={["config", "model_info", "function_calling"]} valuePropName="checked">
+                    <Switch />
+                  </Form.Item>
+                  <Form.Item label="JSON Output" name={["config", "model_info", "json_output"]} valuePropName="checked">
+                    <Switch />
+                  </Form.Item>
+                  <Form.Item label="Structured Output" name={["config", "model_info", "structured_output"]} valuePropName="checked">
+                    <Switch />
+                  </Form.Item>
+                  <Form.Item label="Multiple System Messages" name={["config", "model_info", "multiple_system_messages"]} valuePropName="checked">
+                    <Switch />
+                  </Form.Item>
+                </Flex>
+              )}
+            </Collapse.Panel>
+          </Collapse>
         </Flex>
         {onSubmit && <Button onClick={handleSubmit}>Save</Button>}
       </Flex>

--- a/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OpenAIModelConfigForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OpenAIModelConfigForm.tsx
@@ -16,24 +16,28 @@ const ADVANCED_DEFAULTS = {
   vision: true,
   function_calling: true,
   json_output: false,
+  family: "unknown" as const,
   structured_output: false,
+  multiple_system_messages: false,
 };
 
 function normalizeConfig(config: any, hideAdvancedToggles?: boolean) {
-  const newConfig = { ...config };
+  const newConfig = { ...DEFAULT_OPENAI, ...config };
   if (hideAdvancedToggles) {
-    if (newConfig.model_info) delete newConfig.model_info;
+    if (newConfig.config.model_info) delete newConfig.config.model_info;
   } else {
-    newConfig.model_info = {
+    newConfig.config.model_info = {
       ...ADVANCED_DEFAULTS,
-      ...(newConfig.model_info || {})
+      ...(newConfig.config.model_info || {})
     };
   }
   return newConfig;
 }
 
+
 export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange, onSubmit, value, hideAdvancedToggles }) => {
   const [form] = Form.useForm();
+
   const handleValuesChange = (_: any, allValues: any) => {
     const mergedConfig = { ...DEFAULT_OPENAI.config, ...allValues.config };
     const normalizedConfig = normalizeConfig(mergedConfig, hideAdvancedToggles);
@@ -46,42 +50,18 @@ export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
     const newValue = { ...DEFAULT_OPENAI, config: normalizedConfig };
     if (onSubmit) onSubmit(newValue);
   };
+
+
   useEffect(() => {
     if (value) {
-      form.setFieldsValue(value);
-      // If advanced toggles are shown, ensure defaults are set in the form if missing
-      if (!hideAdvancedToggles) {
-        const modelInfo: Record<string, any> = value.config?.model_info || {};
-        const needsUpdate = (Object.keys(ADVANCED_DEFAULTS) as (keyof typeof ADVANCED_DEFAULTS)[]).some(
-          key => modelInfo[key] === undefined
-        );
-        if (needsUpdate) {
-          form.setFieldsValue({
-            config: {
-              ...value.config,
-              model_info: {
-                ...ADVANCED_DEFAULTS,
-                ...modelInfo
-              }
-            }
-          });
-        }
-      }
-    } else if (!hideAdvancedToggles) {
-      // If no value, set defaults for advanced toggles
-      form.setFieldsValue({
-        config: {
-          ...DEFAULT_OPENAI.config,
-          model_info: { ...ADVANCED_DEFAULTS }
-        }
-      });
+      form.setFieldsValue(normalizeConfig(value, hideAdvancedToggles))
     }
-  }, [value, value?.config, form, hideAdvancedToggles]);
+  }, [value, form]);
 
   return (
     <Form
       form={form}
-      initialValues={value || DEFAULT_OPENAI}
+      initialValues={normalizeConfig(value, hideAdvancedToggles)}
       onFinish={handleSubmit}
       onValuesChange={handleValuesChange}
       layout="vertical"
@@ -90,7 +70,7 @@ export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
         <Form.Item label="Model" name={["config", "model"]} rules={[{ required: true, message: "Please enter the model name" }]}>
           <Input />
         </Form.Item>
-        <Collapse>
+        <Collapse style={{ width: "100%" }}>
           <Collapse.Panel key="1" header="Optional Properties">
             <Form.Item label="API Key" name={["config", "api_key"]} rules={[{ required: false, message: "Please enter your OpenAI API key" }]}>
               <Input />
@@ -101,7 +81,7 @@ export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
             <Form.Item label="Max Retries" name={["config", "max_retries"]} rules={[{ type: "number", min: 1, max: 20, message: "Enter a value between 1 and 20" }]}>
               <Input type="number" />
             </Form.Item>
-            { !hideAdvancedToggles && (
+            {!hideAdvancedToggles && (
               <Flex gap="small" wrap justify="space-between">
                 <Form.Item label="Vision" name={["config", "model_info", "vision"]} valuePropName="checked">
                   <Switch />
@@ -113,6 +93,9 @@ export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
                   <Switch />
                 </Form.Item>
                 <Form.Item label="Structured Output" name={["config", "model_info", "structured_output"]} valuePropName="checked">
+                  <Switch />
+                </Form.Item>
+                <Form.Item label="Multiple System Messages" name={["config", "model_info", "multiple_system_messages"]} valuePropName="checked">
                   <Switch />
                 </Form.Item>
               </Flex>

--- a/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/types.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/types.tsx
@@ -1,9 +1,58 @@
 import { z } from "zod";
 
+export const ModelFamilySchema = z.enum([
+  "gpt-41",
+  "gpt-45",
+  "gpt-4o",
+  "o1",
+  "o3",
+  "o4",
+  "gpt-4",
+  "gpt-35",
+  "r1",
+  "gemini-1.5-flash",
+  "gemini-1.5-pro",
+  "gemini-2.0-flash",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+  "claude-3-haiku",
+  "claude-3-sonnet",
+  "claude-3-opus",
+  "claude-3-5-haiku",
+  "claude-3-5-sonnet",
+  "claude-3-7-sonnet",
+  "claude-4-opus",
+  "claude-4-sonnet",
+  "llama-3.3-8b",
+  "llama-3.3-70b",
+  "llama-4-scout",
+  "llama-4-maverick",
+  "codestral",
+  "open-codestral-mamba",
+  "mistral",
+  "ministral",
+  "pixtral",
+  "unknown"
+]);
+
+export type ModelFamily = z.infer<typeof ModelFamilySchema>;
+
+export const ModelInfoSchema = z.object({
+  vision: z.boolean(),
+  function_calling: z.boolean(),
+  json_output: z.boolean(),
+  family: ModelFamilySchema,
+  structured_output: z.boolean().default(false).optional(),
+  multiple_system_messages: z.boolean().default(false).optional(),
+}).passthrough();
+
+export type ModelInfo = z.infer<typeof ModelInfoSchema>;
+
 export const OpenAIModelConfigSchema = z.object({
   provider: z.literal("OpenAIChatCompletionClient"),
   config: z.object({
     model: z.string().min(1, "Model name is required."),
+    model_info: ModelInfoSchema.optional()
   }).passthrough(),
 }).passthrough();
 
@@ -15,6 +64,7 @@ export const AzureModelConfigSchema = z.object({
     model: z.string().min(1, "Model name is required."),
     azure_endpoint: z.string().min(1, "Azure endpoint is required."),
     azure_deployment: z.string().min(1, "Azure deployment is required."),
+    model_info: ModelInfoSchema.optional()
   }).passthrough(),
 }).passthrough();
 
@@ -24,6 +74,7 @@ export const OllamaModelConfigSchema = z.object({
   provider: z.literal("autogen_ext.models.ollama.OllamaChatCompletionClient"),
   config: z.object({
     model: z.string().min(1, "Model name is required."),
+    model_info: ModelInfoSchema.optional()
   }).passthrough(),
 }).passthrough();
 


### PR DESCRIPTION
model_info was not being set in the correct place. It was being set at `ModelConfig.model_info` when it should have been at `ModelConfig.config.model_info`

I also updated the advanced defaults and provided zod schemas for the expected ModelInfo schema from autogen 0.6.1

This fixes issue #206