### PR TITLE
fixed label for API Key and base url in config

### DIFF
--- a/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/AzureModelConfigForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/AzureModelConfigForm.tsx
@@ -71,7 +71,7 @@ export const AzureModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange,
           <Form.Item required label="Model" name={["config", "model"]}>
             <Input />
           </Form.Item>
-          <Form.Item required label="Azure Endpoint" name={["config", "api_key"]}>
+          <Form.Item required label="Azure API Key" name={["config", "api_key"]}>
             <Input />
           </Form.Item>
           <Form.Item required label="Azure Endpoint" name={["config", "azure_endpoint"]}>

--- a/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OpenAIModelConfigForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OpenAIModelConfigForm.tsx
@@ -75,7 +75,7 @@ export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
             <Form.Item label="API Key" name={["config", "api_key"]} rules={[{ required: false, message: "Please enter your OpenAI API key" }]}>
               <Input />
             </Form.Item>
-            <Form.Item label="Base URL" name={["config", "base_url"]} rules={[{ required: false, message: "Please enter your OpenAI API key" }]}>
+            <Form.Item label="Base URL" name={["config", "base_url"]} rules={[{ required: false, message: "Please enter your Base URL" }]}>
               <Input />
             </Form.Item>
             <Form.Item label="Max Retries" name={["config", "max_retries"]} rules={[{ type: "number", min: 1, max: 20, message: "Enter a value between 1 and 20" }]}>


### PR DESCRIPTION
When running Magentic UI and trying to configure the endpoints in the UI I noticed there is a label "Azure Endpoint" twice while 1 was actually the field for the API Key so i fixed that.

I then checked the other labels and found out that for OpenAI there was a similar mistake with the Base URL so fixed that as well.