### PR TITLE
Many fixes: load state, config, settings save, ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ pip install magentic-ui[azure]
 pip install magentic-ui[ollama]
 ```
 
+You can then pass a config file to the `magentic-ui` command (<a href="#model-client-configuration"> client config</a>) or change the model client inside the UI settings.
+
 For further details on installation please read the   <a href="#️-installation">🛠️ Installation</a> section. For common installation issues and their solutions, please refer to the [troubleshooting document](TROUBLESHOOTING.md). See advanced usage instructions with the command `magentic-ui --help`. 
 
 
@@ -117,6 +119,7 @@ What differentiates Magentic-UI from other browser use offerings is its transpar
   ▶️ <em> Click to watch a video and learn more about Magentic-UI </em>
 </div>
 
+
 ### Autonomous Evaluation
 
 To evaluate its autonomous capabilities, Magentic-UI has been tested against several benchmarks when running with o4-mini: [GAIA](https://huggingface.co/datasets/gaia-benchmark/GAIA) test set (42.52%), which assesses general AI assistants across reasoning, tool use, and web interaction tasks ; [AssistantBench](https://huggingface.co/AssistantBench) test set (27.60%), focusing on realistic, time-consuming web tasks; [WebVoyager](https://github.com/MinorJerry/WebVoyager) (82.2%), measuring end-to-end web navigation in real-world scenarios; and [WebGames](https://webgames.convergence.ai/) (45.5%), evaluating general-purpose web-browsing agents through interactive challenges.
@@ -124,7 +127,7 @@ To reproduce these experimental results, please see the following [instructions]
 
 
 
-If you're interested in reading more checkout our [blog post](https://www.microsoft.com/en-us/research/blog/magentic-ui-an-experimental-human-centered-web-agent/).
+If you're interested in reading more checkout our [technical report](https://www.microsoft.com/en-us/research/wp-content/uploads/2025/07/magentic-ui-report.pdf) and [blog post](https://www.microsoft.com/en-us/research/blog/magentic-ui-an-experimental-human-centered-web-agent/).
 
 ## 🛠️ Installation
 ### Pre-Requisites
@@ -139,7 +142,7 @@ If using Docker Desktop, make sure it is set up to use WSL2:
 
 
 
-2. During the Installation step, you will need to set up your `OPENAI_API_KEY`. To use other models, review the [Custom Client Configuration](#configuration) section below.
+2. During the Installation step, you will need to set up your `OPENAI_API_KEY`. To use other models, review the [Model Client Configuration](#model-client-configuration) section below.
 
 3. You need at least [Python 3.10](https://www.python.org/downloads/) installed.
 
@@ -190,8 +193,31 @@ Once the server is running, you can access the UI at <http://localhost:8081>.
 
 #### Model Client Configuration
 
-If you want to use a different OpenAI key, or if you want to configure use with Azure OpenAI or Ollama, you can do so inside the UI by navigating to settings (top right icon) and changing model configuration.
+If you want to use a different OpenAI key, or if you want to configure use with Azure OpenAI or Ollama, you can do so inside the UI by navigating to settings (top right icon) and changing model configuration. Another option is to pass a yaml config file when you start Magentic-UI which will override any settings in the UI:
 
+```bash
+magentic-ui --port 8081 --config config.yaml
+```
+
+Where the `config.yaml` should look as follows with an AutoGen model client configuration:
+
+```yaml
+gpt4o_client: &gpt4o_client
+    provider: OpenAIChatCompletionClient
+    config:
+      model: gpt-4o-2024-08-06
+      api_key: null
+      base_url: null
+      max_retries: 5
+
+orchestrator_client: *gpt4o_client
+coder_client: *gpt4o_client
+web_surfer_client: *gpt4o_client
+file_surfer_client: *gpt4o_client
+action_guard_client: *gpt4o_client
+plan_learning_client: *gpt4o_client
+```
+You can change the client for each of the agents using the config file and use AzureOpenAI (`AzureOpenAIChatCompletionClient`), Ollama and other clients.
 
 #### MCP Server Configuration
 

--- a/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OpenAIModelConfigForm.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OpenAIModelConfigForm.tsx
@@ -37,16 +37,21 @@ function normalizeConfig(config: any, hideAdvancedToggles?: boolean) {
 
 export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange, onSubmit, value, hideAdvancedToggles }) => {
   const [form] = Form.useForm();
+  const baseUrl = Form.useWatch(['config', 'base_url'], form);
+
+  const shouldHideAdvanced = (config: any) => {
+    return hideAdvancedToggles && !(config?.base_url && config.base_url.trim() !== '');
+  };
 
   const handleValuesChange = (_: any, allValues: any) => {
     const mergedConfig = { ...DEFAULT_OPENAI.config, ...allValues.config };
-    const normalizedConfig = normalizeConfig(mergedConfig, hideAdvancedToggles);
+    const normalizedConfig = normalizeConfig(mergedConfig, shouldHideAdvanced(mergedConfig));
     const newValue = { ...DEFAULT_OPENAI, config: normalizedConfig };
     if (onChange) onChange(newValue);
   };
   const handleSubmit = () => {
     const mergedConfig = { ...DEFAULT_OPENAI.config, ...form.getFieldsValue().config };
-    const normalizedConfig = normalizeConfig(mergedConfig, hideAdvancedToggles);
+    const normalizedConfig = normalizeConfig(mergedConfig, shouldHideAdvanced(mergedConfig));
     const newValue = { ...DEFAULT_OPENAI, config: normalizedConfig };
     if (onSubmit) onSubmit(newValue);
   };
@@ -54,14 +59,14 @@ export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
 
   useEffect(() => {
     if (value) {
-      form.setFieldsValue(normalizeConfig(value, hideAdvancedToggles))
+      form.setFieldsValue(normalizeConfig(value, shouldHideAdvanced(value.config)))
     }
-  }, [value, form]);
+  }, [value, form, hideAdvancedToggles]);
 
   return (
     <Form
       form={form}
-      initialValues={normalizeConfig(value, hideAdvancedToggles)}
+      initialValues={normalizeConfig(value, shouldHideAdvanced(value?.config))}
       onFinish={handleSubmit}
       onValuesChange={handleValuesChange}
       layout="vertical"
@@ -81,7 +86,7 @@ export const OpenAIModelConfigForm: React.FC<ModelConfigFormProps> = ({ onChange
             <Form.Item label="Max Retries" name={["config", "max_retries"]} rules={[{ type: "number", min: 1, max: 20, message: "Enter a value between 1 and 20" }]}>
               <Input type="number" />
             </Form.Item>
-            {!hideAdvancedToggles && (
+            {!shouldHideAdvanced({ base_url: baseUrl }) && (
               <Flex gap="small" wrap justify="space-between">
                 <Form.Item label="Vision" name={["config", "model_info", "vision"]} valuePropName="checked">
                   <Switch />

--- a/frontend/src/components/views/api.ts
+++ b/frontend/src/components/views/api.ts
@@ -443,6 +443,19 @@ export class SettingsAPI {
     if (!data.status)
       throw new Error(data.message || "Failed to update settings");
   }
+
+  async getConfigInfo(): Promise<{ has_config_file: boolean; config_file_path: string | null; config_content: any }> {
+    const response = await fetch(
+      `${this.getBaseUrl()}/settings/config-info`,
+      {
+        headers: this.getHeaders(),
+      }
+    );
+    const data = await response.json();
+    if (!data.status)
+      throw new Error(data.message || "Failed to fetch config info");
+    return data.data;
+  }
 }
 
 export const teamAPI = new TeamAPI();

--- a/src/magentic_ui/agents/_coder.py
+++ b/src/magentic_ui/agents/_coder.py
@@ -641,6 +641,7 @@ class CoderAgent(BaseChatAgent, Component[CoderAgentConfig]):
         """
         # Create message factory for deserialization.
         message_factory = MessageFactory()
+        self._chat_history = []
         for msg_data in state["chat_history"]:
             msg = message_factory.create(msg_data)
             assert isinstance(msg, BaseChatMessage)

--- a/src/magentic_ui/agents/web_surfer/_web_surfer.py
+++ b/src/magentic_ui/agents/web_surfer/_web_surfer.py
@@ -2090,6 +2090,7 @@ class WebSurfer(BaseChatAgent, Component[WebSurferConfig]):
 
         # Load the browser state if it exists
         if web_surfer_state.browser_state is not None:
+            await self.lazy_init()
             assert self._context is not None
             await load_browser_state(self._context, web_surfer_state.browser_state)
 

--- a/src/magentic_ui/backend/datamodel/db.py
+++ b/src/magentic_ui/backend/datamodel/db.py
@@ -195,6 +195,12 @@ class Settings(SQLModel, table=True):
         default_factory=SettingsConfig, sa_column=Column(JSON)
     )
 
+    @field_serializer("config")
+    def serialize_config(self, value: Union[SettingsConfig, dict[str, Any]]) -> dict[str, Any]:
+        if isinstance(value, SettingsConfig):
+            return value.model_dump()
+        return value
+
 
 class Plan(SQLModel, table=True):
     __table_args__ = {"sqlite_autoincrement": True}

--- a/src/magentic_ui/backend/datamodel/db.py
+++ b/src/magentic_ui/backend/datamodel/db.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, List, Optional, Union
 
 from autogen_core import ComponentModel
-from pydantic import field_serializer
+from pydantic import field_serializer, model_validator
 from sqlalchemy import ForeignKey, Integer
 from sqlmodel import JSON, Column, DateTime, Field, SQLModel, func
 
@@ -192,7 +192,7 @@ class Settings(SQLModel, table=True):
     user_id: Optional[str] = None
     version: Optional[str] = "0.0.1"
     config: Union[SettingsConfig, dict[str, Any]] = Field(
-        default_factory=SettingsConfig, sa_column=Column(JSON)
+        default_factory=lambda: SettingsConfig().model_dump(), sa_column=Column(JSON)
     )
 
     @field_serializer("config")

--- a/src/magentic_ui/backend/datamodel/db.py
+++ b/src/magentic_ui/backend/datamodel/db.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, List, Optional, Union
 
 from autogen_core import ComponentModel
-from pydantic import field_serializer, model_validator
+from pydantic import field_serializer
 from sqlalchemy import ForeignKey, Integer
 from sqlmodel import JSON, Column, DateTime, Field, SQLModel, func
 
@@ -196,7 +196,9 @@ class Settings(SQLModel, table=True):
     )
 
     @field_serializer("config")
-    def serialize_config(self, value: Union[SettingsConfig, dict[str, Any]]) -> dict[str, Any]:
+    def serialize_config(
+        self, value: Union[SettingsConfig, dict[str, Any]]
+    ) -> dict[str, Any]:
         if isinstance(value, SettingsConfig):
             return value.model_dump()
         return value

--- a/src/magentic_ui/backend/datamodel/types.py
+++ b/src/magentic_ui/backend/datamodel/types.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Sequence
 from autogen_agentchat.base import TaskResult
 from autogen_agentchat.messages import BaseChatMessage, BaseTextChatMessage
 from autogen_core import ComponentModel
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, Field, field_serializer
 
 
 class MessageConfig(BaseModel):
@@ -89,7 +89,7 @@ class UISettings(BaseModel):
 class SettingsConfig(BaseModel):
     # Backend-specific settings only
     environment: List[EnvironmentVariable] = []
-    ui: UISettings = UISettings()
+    ui: UISettings = Field(default_factory=UISettings)
 
 
 # web request/response data models

--- a/src/magentic_ui/backend/teammanager/teammanager.py
+++ b/src/magentic_ui/backend/teammanager/teammanager.py
@@ -298,7 +298,9 @@ class TeamManager:
                                 await self.team.load_state(state_dict)
                             except json.JSONDecodeError as json_error:
                                 # Log error and skip loading invalid JSON state
-                                logger.warning(f"Warning: Failed to load state - invalid JSON: {json_error}")
+                                logger.warning(
+                                    f"Warning: Failed to load state - invalid JSON: {json_error}"
+                                )
 
                     else:
                         await self.team.load_state(state)

--- a/src/magentic_ui/backend/teammanager/teammanager.py
+++ b/src/magentic_ui/backend/teammanager/teammanager.py
@@ -27,7 +27,7 @@ from autogen_core.logging import LLMCallEvent
 from ...task_team import get_task_team
 from ...teams import GroupChat
 from ...types import RunPaths
-from ...magentic_ui_config import MagenticUIConfig
+from ...magentic_ui_config import MagenticUIConfig, ModelClientConfigs
 from ...input_func import InputFuncType
 from ...agents import WebSurfer
 
@@ -215,46 +215,46 @@ class TeamManager:
             if not self.load_from_config:
                 # The settings_config dictionary provides the Model configs in a key `model_configs`
                 # But MagenticUIConfig expects `model_client_configs` so we need to update that here
-                # settings_model_configs: Dict[str, Any] = {}
-                # if "model_configs" in settings_config:
-                #     try:
-                #         settings_model_configs = yaml.safe_load(
-                #             settings_config["model_configs"]
-                #         )
-                #     except Exception as e:
-                #         logger.warning(
-                #             f"Error loading model configs from UI. Using defaults. Inner exception: {e}"
-                #         )
+                settings_model_configs: Dict[str, Any] = {}
+                if "model_configs" in settings_config:
+                    try:
+                        settings_model_configs = yaml.safe_load(
+                            settings_config["model_configs"]
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Error loading model configs from UI. Using defaults. Inner exception: {e}"
+                        )
 
-                # # Use settings_config values if available, otherwise fall back to instance defaults (self.config)
-                # model_client_configs = ModelClientConfigs(
-                #     orchestrator=settings_model_configs.get(
-                #         "orchestrator_client",
-                #         self.config.get("orchestrator_client", None),
-                #     ),
-                #     web_surfer=settings_model_configs.get(
-                #         "web_surfer_client",
-                #         self.config.get("web_surfer_client", None),
-                #     ),
-                #     coder=settings_model_configs.get(
-                #         "coder_client", self.config.get("coder_client", None)
-                #     ),
-                #     file_surfer=settings_model_configs.get(
-                #         "file_surfer_client",
-                #         self.config.get("file_surfer_client", None),
-                #     ),
-                #     action_guard=settings_model_configs.get(
-                #         "action_guard_client",
-                #         self.config.get("action_guard_client", None),
-                #     ),
-                # )
+                # Use settings_config values if available, otherwise fall back to instance defaults (self.config)
+                model_client_configs = ModelClientConfigs(
+                    orchestrator=settings_model_configs.get(
+                        "orchestrator_client",
+                        self.config.get("orchestrator_client", None),
+                    ),
+                    web_surfer=settings_model_configs.get(
+                        "web_surfer_client",
+                        self.config.get("web_surfer_client", None),
+                    ),
+                    coder=settings_model_configs.get(
+                        "coder_client", self.config.get("coder_client", None)
+                    ),
+                    file_surfer=settings_model_configs.get(
+                        "file_surfer_client",
+                        self.config.get("file_surfer_client", None),
+                    ),
+                    action_guard=settings_model_configs.get(
+                        "action_guard_client",
+                        self.config.get("action_guard_client", None),
+                    ),
+                )
 
                 config_params = {
                     # Lowest priority defaults
                     **self.config,  # type: ignore
                     # Provided settings override defaults
                     **settings_config,  # type: ignore,
-                    # "model_client_configs": model_client_configs,
+                    "model_client_configs": model_client_configs,
                     # These must always be set to the values computed above
                     "playwright_port": playwright_port,
                     "novnc_port": novnc_port,

--- a/src/magentic_ui/backend/utils/utils.py
+++ b/src/magentic_ui/backend/utils/utils.py
@@ -322,15 +322,3 @@ def copy_files_to_run_directory(
     return copied_files
 
 
-def compress_state(state: Dict[Any, Any]) -> str:
-    """Compress state dictionary to a base64 encoded string"""
-    state_json = json.dumps(state)
-    compressed = zlib.compress(state_json.encode("utf-8"))
-    return base64.b64encode(compressed).decode("utf-8")
-
-
-def decompress_state(compressed_state: str) -> Dict[Any, Any]:
-    """Decompress base64 encoded string back to state dictionary"""
-    compressed = base64.b64decode(compressed_state.encode("utf-8"))
-    decompressed = zlib.decompress(compressed)
-    return json.loads(decompressed.decode("utf-8"))

--- a/src/magentic_ui/backend/utils/utils.py
+++ b/src/magentic_ui/backend/utils/utils.py
@@ -7,7 +7,6 @@ from autogen_core import Image
 from loguru import logger
 import shutil
 from typing import Optional
-import zlib
 
 
 def construct_task(
@@ -320,5 +319,3 @@ def copy_files_to_run_directory(
             print(f"Failed to copy file {file_info.get('name')}: {e}")
 
     return copied_files
-
-

--- a/src/magentic_ui/backend/web/managers/connection.py
+++ b/src/magentic_ui/backend/web/managers/connection.py
@@ -35,7 +35,6 @@ from ...datamodel import (
     TeamResult,
 )
 from ...teammanager import TeamManager
-from ...utils.utils import compress_state
 
 logger = logging.getLogger(__name__)
 
@@ -230,9 +229,8 @@ class WebSocketManager:
                     # Save state to run
                     run = await self._get_run(run_id)
                     if run:
-                        # Use compress_state utility to compress the state
-                        state_dict = json.loads(message.state)
-                        run.state = compress_state(state_dict)
+                        # Store state as JSON string
+                        run.state = message.state
                         self.db_manager.upsert(run)
                     continue
 

--- a/src/magentic_ui/backend/web/managers/connection.py
+++ b/src/magentic_ui/backend/web/managers/connection.py
@@ -3,7 +3,6 @@ import logging
 import traceback
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Sequence, Union
-import json
 
 from autogen_agentchat.base._task import TaskResult
 from autogen_agentchat.messages import (

--- a/src/magentic_ui/version.py
+++ b/src/magentic_ui/version.py
@@ -1,3 +1,3 @@
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 __version__ = VERSION
 APP_NAME = "Magentic-UI"


### PR DESCRIPTION
Three bugs fixed:
- settings in UI failing to save/load because of serialization issue
- load/save state broken because of zipping state & agent issues
- --config argument not being respected

Minor issues:
- openaimodel config not showing advanced toggles for custom base url


Changes:

- Readme: clarified config passing to magentic-ui command + add link to technical report
-frontend/src/components/settings/tabs/agentSettings/modelSelector/modelConfigForms/OpenAIModelConfigForm.tsx: fix so that you can change the advanced setting whenever the baseurl field is not empty for vllm and other local models
- src/magentic_ui/agents/_coder.py: load state make sure chat history is reset
- src/magentic_ui/agents/file_surfer/_file_surfer.py: add save and load state methods
- src/magentic_ui/agents/web_surfer/_web_surfer.py: before loading state, make sure to lazy init
- src/magentic_ui/backend/datamodel/db.py and src/magentic_ui/backend/datamodel/types.py: fix json serialization of settings
- src/magentic_ui/backend/teammanager/teammanager.py: 1) make sure config passed through command override model clients from UI, 2) remove zipping of state in load/save state (change to src/magentic_ui/backend/utils/utils.py and src/magentic_ui/backend/web/managers/connection.py)
