### PR TITLE
upragrade the autogen* to 0.7.4 and fixed ensuing compatitible issues

### DIFF
--- a/frontend/src/components/views/chat/chatinput.tsx
+++ b/frontend/src/components/views/chat/chatinput.tsx
@@ -604,8 +604,8 @@ const ChatInput = React.forwardRef<{ focus: () => void }, ChatInputProps>(
       };
     }, [isRelevantPlansVisible]);
 
-      onSubMenuChange("mcp_servers");
-    }, [onSubMenuChange])
+    const goToMcpServersTab = React.useCallback(() => {onSubMenuChange("mcp_servers") 
+    }, [onSubMenuChange]);
     
     const handleMcpServerSelectionChange = React.useCallback((newSelection: string[]) => {
       onSelectedMcpServersChange(newSelection);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "autogen-agentchat==0.5.7",
-    "autogen-core==0.5.7",
-    "autogen-ext[openai,docker,file-surfer,web-surfer,magentic-one,task-centric-memory,mcp]==0.5.7",
+    "autogen-agentchat==0.7.4",
+    "autogen-core==0.7.4",
+    "autogen-ext[openai,docker,file-surfer,web-surfer,magentic-one,task-centric-memory,mcp]==0.7.4",
     "aioconsole",
     "nest_asyncio",
     "docker",

--- a/samples/sample_azure_agent.py
+++ b/samples/sample_azure_agent.py
@@ -274,6 +274,8 @@ async def get_task_team_with_azure_agent(
         )
 
         team = GroupChat(
+            name="azure_agent_team",
+            description="A team of agents that can help with complex math and logic tasks",
             participants=[
                 web_surfer,
                 user_proxy,

--- a/src/magentic_ui/agents/mcp/_agent.py
+++ b/src/magentic_ui/agents/mcp/_agent.py
@@ -90,6 +90,6 @@ class McpAgent(AssistantAgent):
             # Dump the component so we can load it
             workbench_component = workbench.dump_component()
             # Create a copy of the config with the workbench set to the dumped AggregateMcpWorkbench
-            config = config.model_copy(update={"workbench": workbench_component})
+            config = config.model_copy(update={"workbench": [workbench_component]})
 
         return super()._from_config(config)

--- a/src/magentic_ui/backend/web/managers/connection.py
+++ b/src/magentic_ui/backend/web/managers/connection.py
@@ -78,7 +78,7 @@ class WebSocketManager:
             ),
             usage="",
             duration=0,
-        ).model_dump()
+        ).model_dump(mode="json")
 
     def _get_stop_message(self, reason: str) -> dict[str, Any]:
         return TeamResult(
@@ -88,7 +88,7 @@ class WebSocketManager:
             ),
             usage="",
             duration=0,
-        ).model_dump()
+        ).model_dump(mode="json")
 
     async def connect(self, websocket: WebSocket, run_id: int) -> bool:
         try:
@@ -162,7 +162,7 @@ class WebSocketManager:
 
             state = None
             if run:
-                run.task = MessageConfig(content=task, source="user").model_dump()
+                run.task = MessageConfig(content=task, source="user").model_dump(mode="json")
                 run.status = RunStatus.ACTIVE
                 state = run.state
                 self.db_manager.upsert(run)
@@ -253,7 +253,7 @@ class WebSocketManager:
                         await self._save_message(run_id, message)
                     # Capture final result if it's a TeamResult
                     elif isinstance(message, TeamResult):
-                        final_result = message.model_dump()
+                        final_result = message.model_dump(mode="json")
                     self._team_managers[run_id] = team_manager  # Track the team manager
             if (
                 not cancellation_token.is_cancelled()
@@ -308,7 +308,7 @@ class WebSocketManager:
                 created_at=datetime.now(),
                 session_id=run.session_id,
                 run_id=run_id,
-                config=message.model_dump(),
+                config=message.model_dump(mode="json"),
                 user_id=run.user_id,  # Pass the user_id from the run object
             )
             self.db_manager.upsert(db_message)
@@ -333,7 +333,7 @@ class WebSocketManager:
         if run:
             run.status = status
             if team_result:
-                run.team_result = team_result
+                run.team_result = team_result.model_dump(mode="json") if isinstance(team_result, TeamResult) else team_result
             if error:
                 run.error_message = error
             self.db_manager.upsert(run)
@@ -535,7 +535,7 @@ class WebSocketManager:
                 ),
                 usage="",
                 duration=0,
-            ).model_dump()
+            ).model_dump(mode="json")
 
             await self._send_message(
                 run_id,
@@ -583,7 +583,7 @@ class WebSocketManager:
             elif isinstance(message, TeamResult):
                 return {
                     "type": "result",
-                    "data": message.model_dump(),
+                    "data": message.model_dump(mode="json"),
                     "status": "complete",
                 }
             elif isinstance(message, ModelClientStreamingChunkEvent):
@@ -597,7 +597,7 @@ class WebSocketManager:
                     ToolCallExecutionEvent,
                 ),
             ):
-                return {"type": "message", "data": message.model_dump()}
+                return {"type": "message", "data": message.model_dump(mode="json")}
             elif isinstance(message, str):
                 return {
                     "type": "message",
@@ -686,7 +686,7 @@ class WebSocketManager:
                         ),
                         usage="",
                         duration=0,
-                    ).model_dump()
+                    ).model_dump(mode="json")
 
                     run.status = RunStatus.STOPPED
                     run.team_result = interrupted_result

--- a/src/magentic_ui/task_team.py
+++ b/src/magentic_ui/task_team.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from autogen_agentchat.agents import UserProxyAgent
-from autogen_agentchat.base import ChatAgent
+from autogen_agentchat.base import ChatAgent, Team
 from autogen_core import ComponentModel
 from autogen_core.models import ChatCompletionClient
 
@@ -237,7 +237,7 @@ async def get_task_team(
     else:
         memory_provider = None
 
-    team_participants: List[ChatAgent] = [
+    team_participants: List[ChatAgent | Team] = [
         web_surfer,
         user_proxy,
     ]
@@ -248,6 +248,8 @@ async def get_task_team(
     team_participants.extend(mcp_agents)
 
     team = GroupChat(
+        name="task_team",
+        description="A team of agents that can help with the task",
         participants=team_participants,
         orchestrator_config=orchestrator_config,
         model_client=model_client_orch,

--- a/src/magentic_ui/teams/orchestrator/_orchestrator.py
+++ b/src/magentic_ui/teams/orchestrator/_orchestrator.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Mapping, Callable
+from typing import Any, Dict, List, Optional, Mapping, Callable, Sequence
 import io
 import PIL.Image
 from autogen_core import Image as AGImage
@@ -343,7 +343,7 @@ class Orchestrator(BaseGroupChatManager):
         pass
 
     async def select_speaker(
-        self, thread: List[BaseAgentEvent | BaseChatMessage]
+        self, thread: Sequence[BaseAgentEvent | BaseChatMessage]
     ) -> str:
         """Not used in this class."""
         return ""
@@ -407,7 +407,7 @@ class Orchestrator(BaseGroupChatManager):
         await self._output_message_queue.put(message)
 
         await self.publish_message(
-            GroupChatAgentResponse(agent_response=Response(chat_message=message)),
+            GroupChatAgentResponse(response=Response(chat_message=message), name=self._name),
             topic_id=DefaultTopicId(type=self._group_topic_type),
             cancellation_token=cancellation_token,
         )
@@ -540,11 +540,11 @@ class Orchestrator(BaseGroupChatManager):
         self, message: GroupChatAgentResponse, ctx: MessageContext
     ) -> None:
         delta: List[BaseChatMessage] = []
-        if message.agent_response.inner_messages is not None:
-            for inner_message in message.agent_response.inner_messages:
+        if message.response.inner_messages is not None:
+            for inner_message in message.response.inner_messages:
                 delta.append(inner_message)  # type: ignore
-        self._state.message_history.append(message.agent_response.chat_message)
-        delta.append(message.agent_response.chat_message)
+        self._state.message_history.append(message.response.chat_message)
+        delta.append(message.response.chat_message)
 
         if self._termination_condition is not None:
             stop_message = await self._termination_condition(delta)

--- a/src/magentic_ui/tools/mcp/_aggregate_workbench.py
+++ b/src/magentic_ui/tools/mcp/_aggregate_workbench.py
@@ -145,6 +145,7 @@ class AggregateMcpWorkbench(Workbench, Component[AggregateMcpWorkbenchConfig]):
         name: str,
         arguments: Mapping[str, Any] | None = None,
         cancellation_token: CancellationToken | None = None,
+        call_id: str | None = None,
     ) -> ToolResult:
         try:
             # Split the server name from teh tool name


### PR DESCRIPTION
In the newer version
  1. BaseChatMessage prevent Datetime-type field being JSON-serizalized, using model_dump(mode="json") for SQLModel that contains a Datetime field (or its Children contains Datetime)  instead of model_dump()
  2. GroupChat takes 2 extra arguments