### PR TITLE
json format

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ model_config_local_surfer: &client_surfer
     model_info:
       vision: true
       function_calling: true
-      json_output: false
+      json_output: true
       family: "unknown" 
       structured_output: false
       multiple_system_messages: false


### PR DESCRIPTION
Hey guys, in the Fara-7b modelcard, I see:
> For each function call, return a JSON object

Shouldn't `json_output` be set to true in `fara_config.yaml`?