### PR TITLE
add last message to orchestrator history for sentinel

### DIFF
--- a/src/magentic_ui/teams/orchestrator/_orchestrator.py
+++ b/src/magentic_ui/teams/orchestrator/_orchestrator.py
@@ -1636,6 +1636,9 @@ class Orchestrator(BaseGroupChatManager):
                                     "type": "sentinel_error",
                                 },
                             )
+                            # add last message from agent to history
+                            self._state.message_history.append(last_agent_message)
+
                             # inform orchestrator that the step has failed
                             self._state.message_history.append(
                                 TextMessage(
@@ -1687,7 +1690,12 @@ class Orchestrator(BaseGroupChatManager):
                         log_msg,
                         metadata=complete_metadata,
                     )
+
+                    # add last message from agent to history
+                    self._state.message_history.append(last_agent_message)
+
                     # inform orchestrator that the step is completed
+
                     self._state.message_history.append(
                         TextMessage(
                             content=f"Sentinel step '{step.title}' completed successfully. Reason: {reason}",


### PR DESCRIPTION
Closes #475 

Add last message from agent to the orchestrator chat history in sentinel steps.

Before fix:
<img width="1707" height="932" alt="image" src="https://github.com/user-attachments/assets/87369db9-4897-402c-867e-0e34c1c44f95" />





After fix:
<img width="779" height="669" alt="image" src="https://github.com/user-attachments/assets/f30bc195-e294-4e75-a7ee-402bdd75c722" />


Content of rustpad is:

<img width="803" height="349" alt="image" src="https://github.com/user-attachments/assets/879ad499-e167-45dc-96a7-9f69cbcec658" />
