### PR TITLE
Fix parallelization and a couple small updates for webvoyager benchmark

### DIFF
--- a/experiments/eval/README.md
+++ b/experiments/eval/README.md
@@ -1,6 +1,7 @@
 # Reproducing Experimental Results
 
 Make sure to clone the repo and install Magentic-UI with the following command:
+
 ```bash
 pip install magentic-ui[eval]
 ```
@@ -11,7 +12,6 @@ To evaluate an existing run or get partial results, replace "--mode run" with "-
 
 The run.py script takes care of running Magentic-UI on the benchmark of choice. It will download the data in `./data` folder at the root of the repo and store the run logs inside `runs/[SYSTEM NAME]/[DATASET NAME]/[SPLIT NAME]/[RUN ID]`. Inside this folder you'll find a folder for each task with files containing the run messages (`[TASK_ID]_messages.json`), time data (`times.json`), token usage data (`model_tokens_usage.json`), evaluation scores (`score.json`) and any screenshots (`screenshot_raw_[TIMESTAMP].png` and `screenshot*som*[TIMESTAMP].png`) or produced files. You will also find a `metrics.json` file with metrics for the entire run.
 
-
 **NOTE:** Make sure to create a config file with your model client endpoints. We provide a template config file [config_template.yaml](../endpoint_configs/config_template.yaml) that you should adapt. You should copy and rename this file to `config.yaml` inside `experiments/endpoint_configs` directory.
 
 ## WebGames
@@ -21,6 +21,8 @@ python experiments/eval/run.py --current-dir . --dataset WebGames --split test  
 ```
 
 ## WebVoyager
+
+Add `eval_client` to config.yaml if using gpt_eval
 
 ```bash
 python experiments/eval/run.py  --current-dir . --dataset WebVoyager --split webvoyager  --run-id 1 --simulated-user-type none --parallel 1 --config experiments/endpoint_configs/config.yaml --web-surfer-only true --mode run

--- a/experiments/eval/run.py
+++ b/experiments/eval/run.py
@@ -46,18 +46,11 @@ class MagenticUISystemConstructor:
 
 
 class WebVoyagerBenchmarkConstructor:
-    DEFAULT_EVAL_CONFIG = {
-        "provider": "OpenAIChatCompletionClient",
-        "config": {"model": "gpt-4o-2024-08-06"},
-        "max_retries": 10,
-    }
-
     def __init__(self, eval_client_config: Optional[Dict[str, Any]] = None):
-        self.eval_client_config = eval_client_config or self.DEFAULT_EVAL_CONFIG
+        self.eval_client_config = eval_client_config
 
-    def __call__(self, data_dir: str = "WebVoyager"):
+    def __call__(self, data_dir: str = "WebVoyager", name: str = "WebVoyager") -> Benchmark:
         """Create a fresh benchmark instance in the worker process."""
-
         benchmark = WebVoyagerBenchmark(
             data_dir=data_dir,
             eval_method="gpt_eval",
@@ -152,9 +145,9 @@ def run_system_evaluation(
     """
     benchmark_constructor: Optional[Callable[..., Benchmark]] = None
     if args.dataset == "WebVoyager":
-        eval_client_config = config.get("eval_client") if config else None
-        benchmark_constructor = WebVoyagerBenchmarkConstructor(eval_client_config)
-
+        benchmark_constructor = WebVoyagerBenchmarkConstructor(
+            config.get("eval_client") if config else None
+        )
     reload_system_per_task = args.parallel > 1
     reload_benchmark_per_task = False
 

--- a/experiments/eval/run.py
+++ b/experiments/eval/run.py
@@ -9,7 +9,61 @@ from systems.magentic_ui_sim_user_system import MagenticUISimUserSystem
 from magentic_ui.eval.systems import LLMSystem
 from magentic_ui.eval.benchmarks import WebVoyagerBenchmark
 from magentic_ui.eval.benchmark import Benchmark
-from autogen_core.models import ChatCompletionClient
+
+class LLMSystemConstructor:
+    def __init__(self, config: Optional[Dict[str, Any]]):
+        self.config = config
+
+    def __call__(self):
+        """Create a fresh LLMSystem instance."""
+        return LLMSystem(
+            system_name="LLM",
+            endpoint_config=self.config.get("model_client") if self.config else None,
+        )
+
+
+class MagenticUISystemConstructor:
+    def __init__(self, config: Optional[Dict[str, Any]], args: argparse.Namespace):
+        self.config = config
+        self.simulated_user_type = args.simulated_user_type
+        self.web_surfer_only = args.web_surfer_only
+        self.how_helpful_user_proxy = args.how_helpful_user_proxy
+        self.dataset = args.dataset
+
+    def __call__(self):
+        """Create a fresh MagenticUISimUserSystem instance."""
+        return MagenticUISimUserSystem(
+            simulated_user_type=self.simulated_user_type,
+            endpoint_config_orch=self.config.get("orchestrator_client") if self.config else None,
+            endpoint_config_websurfer=self.config.get("web_surfer_client") if self.config else None,
+            endpoint_config_coder=self.config.get("coder_client") if self.config else None,
+            endpoint_config_file_surfer=self.config.get("file_surfer_client") if self.config else None,
+            endpoint_config_user_proxy=self.config.get("user_proxy_client") if self.config else None,
+            web_surfer_only=self.web_surfer_only,
+            how_helpful_user_proxy=self.how_helpful_user_proxy,
+            dataset_name=self.dataset,
+        )
+
+
+class WebVoyagerBenchmarkConstructor:
+    DEFAULT_EVAL_CONFIG = {
+        "provider": "OpenAIChatCompletionClient",
+        "config": {"model": "gpt-4o-2024-08-06"},
+        "max_retries": 10,
+    }
+
+    def __init__(self, eval_client_config: Optional[Dict[str, Any]] = None):
+        self.eval_client_config = eval_client_config or self.DEFAULT_EVAL_CONFIG
+
+    def __call__(self, data_dir: str = "WebVoyager"):
+        """Create a fresh benchmark instance in the worker process."""
+
+        benchmark = WebVoyagerBenchmark(
+            data_dir=data_dir,
+            eval_method="gpt_eval",
+            eval_client_config=self.eval_client_config,
+        )
+        return benchmark
 
 
 def save_experiment_args(args: argparse.Namespace, system_name: str) -> None:
@@ -98,32 +152,12 @@ def run_system_evaluation(
     """
     benchmark_constructor: Optional[Callable[..., Benchmark]] = None
     if args.dataset == "WebVoyager":
-        # Use eval_client from config if available, otherwise fall back to OpenAI
         eval_client_config = config.get("eval_client") if config else None
+        benchmark_constructor = WebVoyagerBenchmarkConstructor(eval_client_config)
 
-        if eval_client_config:
-            client = ChatCompletionClient.load_component(eval_client_config)
-        else:
-            client = ChatCompletionClient.load_component(
-                {
-                    "provider": "OpenAIChatCompletionClient",
-                    "config": {
-                        "model": "gpt-4o-2024-08-06",
-                    },
-                    "max_retries": 10,
-                }
-            )
+    reload_system_per_task = args.parallel > 1
+    reload_benchmark_per_task = False
 
-        def create_benchmark(data_dir="WebVoyager", name="WebVoyager"):
-            benchmark = WebVoyagerBenchmark(
-                data_dir=data_dir,
-                eval_method="gpt_eval",
-                model_client=client,
-            )
-            return benchmark
-
-        benchmark_constructor = create_benchmark
-        # Load it into memory
     if args.mode == "eval":
         evaluate_benchmark_func(
             benchmark_name=args.dataset,
@@ -150,6 +184,8 @@ def run_system_evaluation(
             system_constructor=system_constructor,
             subsample=args.subsample if args.subsample < 1 else None,
             redo_eval=args.redo_eval,
+            reload_system_per_task=reload_system_per_task,
+            reload_benchmark_per_task=reload_benchmark_per_task,
         )
 
 
@@ -164,27 +200,16 @@ def run_system_sim_user(args: argparse.Namespace, system_name: str) -> None:
     config = load_config(args.config)
 
     if system_name == "LLM":
-        # Use LLMSystem for LLM-based evaluations
-        system = LLMSystem(
-            system_name=system_name,
-            endpoint_config=config.get("model_client") if config else None,
-        )
+        constructor = LLMSystemConstructor(config)
     else:
-        system = MagenticUISimUserSystem(
-            simulated_user_type=args.simulated_user_type,
-            endpoint_config_orch=config.get("orchestrator_client") if config else None,
-            endpoint_config_websurfer=config.get("web_surfer_client") if config else None,
-            endpoint_config_coder=config.get("coder_client") if config else None,
-            endpoint_config_file_surfer=config.get("file_surfer_client")
-            if config
-            else None,
-            endpoint_config_user_proxy=config.get("user_proxy_client") if config else None,
-            web_surfer_only=args.web_surfer_only,
-            how_helpful_user_proxy=args.how_helpful_user_proxy,
-            dataset_name=args.dataset,
-        )
+        constructor = MagenticUISystemConstructor(config, args)
 
-    run_system_evaluation(args, system, system_name, config)
+    if args.parallel > 1:
+        system_constructor = constructor
+    else:
+        system_constructor = constructor()  # Create instance immediately for reuse
+
+    run_system_evaluation(args, system_constructor, system_name, config)
 
 
 def main() -> None:

--- a/experiments/eval/run.py
+++ b/experiments/eval/run.py
@@ -98,16 +98,21 @@ def run_system_evaluation(
     """
     benchmark_constructor: Optional[Callable[..., Benchmark]] = None
     if args.dataset == "WebVoyager":
-        # Download the dataset (only needed once)
-        client = ChatCompletionClient.load_component(
-            {
-                "provider": "OpenAIChatCompletionClient",
-                "config": {
-                    "model": "gpt-4o-2024-08-06",
-                },
-                "max_retries": 10,
-            }
-        )
+        # Use eval_client from config if available, otherwise fall back to OpenAI
+        eval_client_config = config.get("eval_client") if config else None
+
+        if eval_client_config:
+            client = ChatCompletionClient.load_component(eval_client_config)
+        else:
+            client = ChatCompletionClient.load_component(
+                {
+                    "provider": "OpenAIChatCompletionClient",
+                    "config": {
+                        "model": "gpt-4o-2024-08-06",
+                    },
+                    "max_retries": 10,
+                }
+            )
 
         def create_benchmark(data_dir="WebVoyager", name="WebVoyager"):
             benchmark = WebVoyagerBenchmark(

--- a/src/magentic_ui/eval/benchmarks/webvoyager/webvoyager.py
+++ b/src/magentic_ui/eval/benchmarks/webvoyager/webvoyager.py
@@ -52,8 +52,10 @@ class WebVoyagerBenchmark(Benchmark):
     and evaluates predictions using the GAIA evaluator.
     """
 
-    DATA_URL = "https://raw.githubusercontent.com/MinorJerry/WebVoyager/main/data/WebVoyager_data.jsonl"
-    REFERENCE_URL = "https://raw.githubusercontent.com/MinorJerry/WebVoyager/main/data/reference_answer.json"
+    # DATA_URL = "https://raw.githubusercontent.com/MinorJerry/WebVoyager/main/data/WebVoyager_data.jsonl"
+    # REFERENCE_URL = "https://raw.githubusercontent.com/MinorJerry/WebVoyager/main/data/reference_answer.json"
+    DATA_URL = "https://raw.githubusercontent.com/microsoft/fara/main/webeval/data/webvoyager/WebVoyager_data_08312025.jsonl"
+    REFERENCE_URL = "https://raw.githubusercontent.com/microsoft/fara/main/webeval/data/webvoyager/reference_answer.json"
     GAIA_DATA_URL = "https://raw.githubusercontent.com/MinorJerry/WebVoyager/main/data/GAIA_web.jsonl"
 
     def __init__(

--- a/src/magentic_ui/eval/benchmarks/webvoyager/webvoyager.py
+++ b/src/magentic_ui/eval/benchmarks/webvoyager/webvoyager.py
@@ -63,7 +63,7 @@ class WebVoyagerBenchmark(Benchmark):
         name: str = "WebVoyager",
         data_dir: Union[str, None] = None,
         eval_method: str = "exact_match",
-        model_client: ChatCompletionClient | None = None,
+        eval_client_config: Dict[str, Any] | None = None,
     ):
         assert data_dir is not None, "data_dir must be provided for WebVoyagerBenchmark"
         super().__init__(
@@ -73,9 +73,9 @@ class WebVoyagerBenchmark(Benchmark):
         if eval_method not in ["exact_match", "gpt_eval"]:
             raise ValueError("eval_method must be 'exact_match' or 'gpt_eval'")
         self.eval_method = eval_method
-        if eval_method == "gpt_eval" and model_client is None:
-            raise ValueError("model_client must be provided for gpt_eval")
-        self.model_client = model_client
+        if eval_method == "gpt_eval" and eval_client_config is None:
+            raise ValueError("eval_client_config must be provided for gpt_eval")
+        self.eval_client_config = eval_client_config
         assert self.data_dir is not None
         self.data_file = os.path.join(self.data_dir, "WebVoyager_data.jsonl")
         self.reference_file = os.path.join(self.data_dir, "reference_answer.json")
@@ -171,13 +171,30 @@ class WebVoyagerBenchmark(Benchmark):
             return WebVoyagerEvalResult(score=score, reasoning="")
         elif self.eval_method == "gpt_eval":
             score, gpt_response_text = asyncio.run(
-                self.gpt_evaluator_async(task, candidate)
+                self._gpt_eval_with_cleanup(task, candidate)
             )
             return WebVoyagerEvalResult(score=score, reasoning=gpt_response_text)
         raise ValueError(f"Unknown eval_method: {self.eval_method}")
 
-    async def gpt_evaluator_async(
+    async def _gpt_eval_with_cleanup(
         self, task: AllTaskTypes, candidate: AllCandidateTypes
+    ) -> Tuple[float, str]:
+        """
+        Wrapper that creates a fresh model client per task, evaluates, and cleans up properly.
+        This ensures proper event loop management and resource cleanup.
+        """
+        # Create fresh client for this evaluation task
+        model_client = ChatCompletionClient.load_component(self.eval_client_config)
+
+        try:
+            return await self.gpt_evaluator_async(task, candidate, model_client)
+        finally:
+            # Cleanup client before event loop closes
+            if hasattr(model_client, 'close'):
+                await model_client.close()
+
+    async def gpt_evaluator_async(
+        self, task: AllTaskTypes, candidate: AllCandidateTypes, model_client: ChatCompletionClient
     ) -> Tuple[float, str]:
         """
         Adapted from https://github.com/MinorJerry/WebVoyager/blob/main/evaluation/auto_eval.py
@@ -243,8 +260,8 @@ class WebVoyagerBenchmark(Benchmark):
         ]
 
         # Now call the GPT model
-        assert self.model_client is not None
-        response = await self.model_client.create(messages)
+        assert model_client is not None
+        response = await model_client.create(messages)
         assert isinstance(response.content, str)
         gpt_response_text = response.content
         # Parse out the text from the model

--- a/src/magentic_ui/eval/core.py
+++ b/src/magentic_ui/eval/core.py
@@ -312,13 +312,6 @@ def run_benchmark_func(
     if seed is not None:
         random.seed(seed)
 
-    # Validate reload_benchmark_per_task with parallel
-    if reload_benchmark_per_task and parallel > 1:
-        logger.info(
-            "reload_benchmark_per_task=True is not supported in parallel mode. Setting to False."
-        )
-        reload_benchmark_per_task = False
-
     # Prepare benchmark constructor if needed
     if benchmark_constructor is None and benchmark_name:
         benchmark_class = load_benchmark_class(benchmark_name)


### PR DESCRIPTION
Fixes https://github.com/microsoft/magentic-ui2.0/issues/24

### This PR includes multiple fixes:
#### Fix --parallel: 
Currently webvoyager benchmark crashes when parallel > 1. The error is:
```
  File "experiments/eval/run.py", line 187, in run_system_sim_user
    run_system_evaluation(args, system, system_name, config)
  File "experiments/eval/run.py", line 141, in run_system_evaluation
    run_evaluate_benchmark_func(
 ....
  File ".local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/multiprocessing/connection.py", line 206, in send
    self._send_bytes(_ForkingPickler.dumps(obj))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
AttributeError: Can't get local object 'get_bearer_token_provider.<locals>.wrapper'
```
**_Root cause of the bug_**:
 Python's multiprocessing needs to pickle objects to send them to worker processes. The code was passing system and benchmark instances that contained unpicklable variables like azure token provider, browser instances etc

This PR passes constructors for parallel mode and refresh the system per task.
#### Other fixes:   
- Updated webvoyager task list to be the same in Fara repo. 
- Support custom eval client and fall back to open ai
- Clean up clients properly on exceptions