### PR TITLE
Fixed data parsing bug when messages contain the string 'data'

### DIFF
--- a/src/magentic_ui/agents/web_surfer/_tool_definitions.py
+++ b/src/magentic_ui/agents/web_surfer/_tool_definitions.py
@@ -663,9 +663,9 @@ TOOL_UPLOAD_FILE: ToolSchema = load_tool(
                 },
                 "required": ["explanation", "target_id", "file_path"],
             },
-            "metadata": {
-                "requires_approval": "always",
-            },
+        },
+        "metadata": {
+            "requires_approval": "always",
         },
     }
 )

--- a/src/magentic_ui/backend/web/managers/connection.py
+++ b/src/magentic_ui/backend/web/managers/connection.py
@@ -567,7 +567,7 @@ class WebSocketManager:
 
                 message_content: list[dict[str, Any]] = []
                 for row in message_dump["content"]:
-                    if "data" in row:
+                    if isinstance(row, dict) and "data" in row:
                         message_content.append(
                             {
                                 "url": f"data:image/png;base64,{row['data']}",


### PR DESCRIPTION
There was a bug where message parsing fails when it contains the string 'data'.

Also, the action guard value in the upload_file tool was nested incorrectly.