### PR TITLE
Harden Bearcubs benchmark ZIP extraction

### DIFF
--- a/src/magentic_ui/eval/benchmarks/bearcubs/bearcubs.py
+++ b/src/magentic_ui/eval/benchmarks/bearcubs/bearcubs.py
@@ -3,6 +3,7 @@ import json
 import logging
 import zipfile
 import requests
+from pathlib import PurePosixPath
 from typing import List, Dict
 from ...benchmark import Benchmark
 from ...models import (
@@ -12,6 +13,15 @@ from ...models import (
     AllCandidateTypes,
     AllEvalResultTypes,
 )
+
+
+def _safe_zip_members(zip_ref: zipfile.ZipFile) -> list[zipfile.ZipInfo]:
+    members = zip_ref.infolist()
+    for member in members:
+        member_path = PurePosixPath(member.filename.replace("\\", "/"))
+        if member_path.is_absolute() or ".." in member_path.parts:
+            raise ValueError(f"Unsafe path in Bearcubs ZIP archive: {member.filename}")
+    return members
 
 
 class BearcubsBenchmark(Benchmark):
@@ -56,7 +66,7 @@ class BearcubsBenchmark(Benchmark):
 
         # Extract zip file
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
-            zip_ref.extractall(self.data_dir)
+            zip_ref.extractall(self.data_dir, members=_safe_zip_members(zip_ref))
 
         # Remove zip file
         os.remove(zip_path)

--- a/tests/test_bearcubs_benchmark.py
+++ b/tests/test_bearcubs_benchmark.py
@@ -1,0 +1,72 @@
+import importlib.util
+import io
+import sys
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+def _load_bearcubs_module():
+    benchmark_module = types.ModuleType("magentic_ui.eval.benchmark")
+
+    class Benchmark:
+        pass
+
+    benchmark_module.Benchmark = Benchmark
+    models_module = types.ModuleType("magentic_ui.eval.models")
+    for name in [
+        "BaseTask",
+        "BaseEvalResult",
+        "AllTaskTypes",
+        "AllCandidateTypes",
+        "AllEvalResultTypes",
+    ]:
+        setattr(models_module, name, object)
+
+    sys.modules.setdefault("magentic_ui.eval.benchmark", benchmark_module)
+    sys.modules.setdefault("magentic_ui.eval.models", models_module)
+
+    module_path = (
+        Path(__file__).parents[1]
+        / "src"
+        / "magentic_ui"
+        / "eval"
+        / "benchmarks"
+        / "bearcubs"
+        / "bearcubs.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "magentic_ui.eval.benchmarks.bearcubs.bearcubs", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _zip_file(entries: dict[str, str]) -> zipfile.ZipFile:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zip_file:
+        for name, content in entries.items():
+            zip_file.writestr(name, content)
+    buffer.seek(0)
+    return zipfile.ZipFile(buffer, "r")
+
+
+def test_bearcubs_zip_members_reject_traversal_path():
+    bearcubs = _load_bearcubs_module()
+
+    with _zip_file({"../escape.json": "{}"}) as zip_ref:
+        with pytest.raises(ValueError, match="Unsafe path"):
+            bearcubs._safe_zip_members(zip_ref)
+
+
+def test_bearcubs_zip_members_allow_dataset_file():
+    bearcubs = _load_bearcubs_module()
+
+    with _zip_file({"BearCubs_20250310.json": "{}"}) as zip_ref:
+        members = bearcubs._safe_zip_members(zip_ref)
+
+    assert [member.filename for member in members] == ["BearCubs_20250310.json"]


### PR DESCRIPTION
This adds path validation before extracting the downloaded Bearcubs benchmark ZIP.

Changes:
- reject absolute and traversal paths in ZIP members before extraction
- pass the validated member list to extractall
- add focused tests for accepted dataset members and rejected traversal members

Validation:
- python3 -m py_compile src/magentic_ui/eval/benchmarks/bearcubs/bearcubs.py tests/test_bearcubs_benchmark.py
- uv run --no-project --with pytest --with requests python -m pytest -q tests/test_bearcubs_benchmark.py
- uv run --no-project --with ruff==0.4.8 ruff check src/magentic_ui/eval/benchmarks/bearcubs/bearcubs.py tests/test_bearcubs_benchmark.py
- uv run --no-project --with ruff==0.4.8 ruff format --check src/magentic_ui/eval/benchmarks/bearcubs/bearcubs.py tests/test_bearcubs_benchmark.py
- git diff --check