### PR TITLE
fix(security): resolve CodeQL py/path-injection alert

### DIFF
--- a/src/magentic_ui/backend/teammanager/teammanager.py
+++ b/src/magentic_ui/backend/teammanager/teammanager.py
@@ -448,8 +448,9 @@ class TeamManager:
                 for d in mount_dirs:
                     n = normalize_host_path(d)
                     n = os.path.expanduser(n)
-                    # validate_host_path does its own realpath() + denylist; it
-                    # raises ValueError for any path outside the allowed set.
+                    # validate_host_path canonicalizes via realpath() and raises
+                    # ValueError if the path doesn't exist, isn't a directory,
+                    # or matches the sensitive denylist (.ssh, /etc, etc.).
                     mount_paths.append(validate_host_path(n))
                 workspace_path = os.fspath(host_run_dir.resolve())
             task = self._augment_task_with_mounts(task, mount_paths, workspace_path)

--- a/src/magentic_ui/backend/teammanager/teammanager.py
+++ b/src/magentic_ui/backend/teammanager/teammanager.py
@@ -447,7 +447,9 @@ class TeamManager:
                 mount_paths: list[str] = []
                 for d in mount_dirs:
                     n = normalize_host_path(d)
-                    n = os.fspath(Path(n).expanduser().resolve())
+                    n = os.path.expanduser(n)
+                    # validate_host_path does its own realpath() + denylist; it
+                    # raises ValueError for any path outside the allowed set.
                     mount_paths.append(validate_host_path(n))
                 workspace_path = os.fspath(host_run_dir.resolve())
             task = self._augment_task_with_mounts(task, mount_paths, workspace_path)

--- a/src/magentic_ui/sandbox/_quicksand.py
+++ b/src/magentic_ui/sandbox/_quicksand.py
@@ -272,8 +272,9 @@ class QuicksandSandbox(SandboxBase):
         for host_dir in host_dirs or []:
             normalized = normalize_host_path(host_dir)
             normalized = os.path.expanduser(normalized)
-            # validate_host_path does its own realpath() + denylist; it raises
-            # ValueError for any path outside the allowed set.
+            # validate_host_path canonicalizes via realpath() and raises
+            # ValueError if the path doesn't exist, isn't a directory, or
+            # matches the sensitive denylist (.ssh, .aws, /etc, WSL AppData).
             normalized = validate_host_path(normalized)
             dir_name = extract_dir_basename(normalized)
             validate_dir_name(dir_name, host_dir)

--- a/src/magentic_ui/sandbox/_quicksand.py
+++ b/src/magentic_ui/sandbox/_quicksand.py
@@ -8,6 +8,7 @@ multi-tenant workspace isolation.
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from typing import Any
 
@@ -270,7 +271,9 @@ class QuicksandSandbox(SandboxBase):
         # Add user-selected host dirs
         for host_dir in host_dirs or []:
             normalized = normalize_host_path(host_dir)
-            normalized = str(Path(normalized).expanduser().resolve())
+            normalized = os.path.expanduser(normalized)
+            # validate_host_path does its own realpath() + denylist; it raises
+            # ValueError for any path outside the allowed set.
             normalized = validate_host_path(normalized)
             dir_name = extract_dir_basename(normalized)
             validate_dir_name(dir_name, host_dir)


### PR DESCRIPTION
Drop the redundant `Path(n).expanduser().resolve()` before `validate_host_path()`. That function already calls `os.path.realpath()` internally before applying the denylist, so we were resolving the path twice. Replace with the lighter `os.path.expanduser()` (string-only, no filesystem access).

Behavior is functionally unchanged. The CodeQL py/path-injection signal no longer fires because user input no longer flows into a path construct before the sanitizer.

One side effect: `validate_host_path` logs a `Mount audit: path resolves through symlink ...` warning when realpath differs from abspath. The previous pre-resolve was silently suppressing that audit for symlinked mount dirs — now it'll surface in the logs as intended.